### PR TITLE
loan lifecycle/timing updates + ui tweaks

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -356,5 +356,6 @@
         </table>
     </fieldset>
   </div>
+  <modal-manager></modal-manager>
 </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -242,6 +242,12 @@
       });
     });
 
+    document.querySelector('#show_warning_modal').addEventListener('click', () => {
+      if (iaBookActions.lendingStatus.user_has_browsed) {
+        iaBookActions.showWarningModal();
+      }
+    });
+
     document.querySelectorAll('.availableToBorrow input[type=radio]').forEach((item) => {
       item.addEventListener('click', (e) => {
         if (e.target.value === 'available_to_borrow') {
@@ -334,6 +340,9 @@
               <label><input type="radio" name="browse" value="available_to_browse" />available_to_browse</label>
               <label><input type="radio" name="browse" value="user_has_browsed" />user_has_browsed</label>
               <label><input type="radio" name="browse" value="browsingExpired" />browsingExpired</label>
+              <div>
+                <button id="show_warning_modal">When Browsing (`user_has_browsed`), show Warning Modal</button>
+              </div>
             </td>
             <td class="availableToBorrow">
               <label><input type="radio" name="borrow" value="available_to_borrow" />available_to_borrow</label>

--- a/demo/index.html
+++ b/demo/index.html
@@ -323,6 +323,12 @@
         })
       );
     })
+
+    // listen for IABookReader:BrowsingHasExpired
+    window.addEventListener('IABookReader:BrowsingHasExpired', () => {
+      console.log('IABookReader:BrowsingHasExpired EVENT FIRED');
+      alert('IABookReader:BrowsingHasExpired EVENT FIRED');
+    });
 </script>
 
   <div>

--- a/demo/index.html
+++ b/demo/index.html
@@ -245,7 +245,6 @@
     document.querySelector('#show_warning_modal').addEventListener('click', async () => {
       if (!iaBookActions.lendingStatus.user_has_browsed) {
         const newLendingStatus = { ...iaBookActions.lendingStatus, user_has_browsed: true };
-        await new Promise(resolve => setTimeout(resolve, 5000));
         iaBookActions.lendingStatus = newLendingStatus;
         await iaBookActions.updateComplete;
       }

--- a/demo/index.html
+++ b/demo/index.html
@@ -242,10 +242,30 @@
       });
     });
 
-    document.querySelector('#show_warning_modal').addEventListener('click', () => {
+    document.querySelector('#show_warning_modal').addEventListener('click', async () => {
+      if (!iaBookActions.lendingStatus.user_has_browsed) {
+        const newLendingStatus = { ...iaBookActions.lendingStatus, user_has_browsed: true };
+        await new Promise(resolve => setTimeout(resolve, 5000));
+        iaBookActions.lendingStatus = newLendingStatus;
+        await iaBookActions.updateComplete;
+      }
+
+      iaBookActions.showWarningModal();
+
       if (iaBookActions.lendingStatus.user_has_browsed) {
         iaBookActions.showWarningModal();
       }
+    });
+
+    document.querySelector('#show_expired_modal').addEventListener('click', async () => {
+      if (!iaBookActions.lendingStatus.user_has_browsed) {
+        const newLendingStatus = { ...iaBookActions.lendingStatus, user_has_browsed: true };
+        iaBookActions.lendingStatus = newLendingStatus;
+        await iaBookActions.updateComplete;
+      }
+      await new Promise(resolve => setTimeout(resolve, 5000));
+
+      iaBookActions.browseHasExpired();
     });
 
     document.querySelectorAll('.availableToBorrow input[type=radio]').forEach((item) => {
@@ -342,6 +362,10 @@
               <label><input type="radio" name="browse" value="browsingExpired" />browsingExpired</label>
               <div>
                 <button id="show_warning_modal">When Browsing (`user_has_browsed`), show Warning Modal</button>
+              </div>
+              <div>
+                <button id="show_expired_modal">While Browsing (`user_has_browsed`), Expire book & show its modal</button>
+                how_expired_modal
               </div>
             </td>
             <td class="availableToBorrow">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-book-actions",
-  "version": "0.1.10",
+  "version": "0.1.11-b38",
   "description": "Bookreader actions for borrowable book",
   "author": "Internet Archive",
   "license": "AGPL-3.0-only",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-book-actions",
-  "version": "0.1.11-b39",
+  "version": "0.1.11-b62",
   "description": "Bookreader actions for borrowable book",
   "author": "Internet Archive",
   "license": "AGPL-3.0-only",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-book-actions",
-  "version": "0.1.11-b38",
+  "version": "0.1.11-b39",
   "description": "Bookreader actions for borrowable book",
   "author": "Internet Archive",
   "license": "AGPL-3.0-only",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "test:watch": "web-test-runner --watch --playwright --browsers chromium firefox webkit"
   },
   "dependencies": {
-    "@internetarchive/ia-activity-indicator": "^0.0.4",
     "@internetarchive/icon-info": "^1.2.6",
     "@internetarchive/local-cache": "^0.2.1",
     "@internetarchive/modal-manager": "^0.2.12",

--- a/src/components/collapsible-action-group.js
+++ b/src/components/collapsible-action-group.js
@@ -63,15 +63,16 @@ export class CollapsibleActionGroup extends ActionsHandler {
       this.resetActions();
     }
 
-    if (changed.has('autoRenew') && this.autoRenew === true) {
+    if (changed.has('autoRenew') && this.autoRenew) {
       this.dispatchLoanEvent('autoRenew');
     }
 
-    if (changed.has('autoReturn') && this.autoReturn === true) {
+    const requestingAutoreturn = changed.has('autoReturn') && this.autoReturn;
+    if (requestingAutoreturn) {
       this.dispatchLoanEvent('autoReturn');
     }
 
-    if (changed.has('returnNow') && this.returnNow === true) {
+    if (changed.has('returnNow') && this.returnNow && !requestingAutoreturn) {
       this.dispatchLoanEvent('returnNow', { borrowType: 'browse' });
     }
   }

--- a/src/components/timer-countdown.js
+++ b/src/components/timer-countdown.js
@@ -35,7 +35,7 @@ export default class TimerCountdown extends LitElement {
    * get remaining time with timeunit
    *
    * @memberof TimerCountdown
-   * @return string - seconds left
+   * @return string - minutes left
    */
   get remainingTime() {
     const unitOfTime = 'minute';

--- a/src/components/timer-countdown.js
+++ b/src/components/timer-countdown.js
@@ -3,32 +3,43 @@ import { html, css, LitElement } from 'lit';
 export default class TimerCountdown extends LitElement {
   static get properties() {
     return {
-      secondsLeftOnLoan: { type: Number }, // in seconds
+      secondsLeftOnLoan: { type: Number },
+      displayTime: { type: Boolean },
     };
   }
 
   constructor() {
     super();
 
-    /**
-     * seconds left in current loan
-     * @type {number}
-     */
     this.secondsLeftOnLoan = 0;
+    this.displayTime = false;
+  }
+
+  get minutesLeftOnLoan() {
+    let timeLeft = Math.round(this.secondsLeftOnLoan);
+
+    // convert time from second to minute
+    timeLeft = Math.ceil(timeLeft / 60);
+
+    if (timeLeft < 10) {
+      timeLeft = `0:0${timeLeft}`;
+    } else if (timeLeft === 60) {
+      timeLeft = `1:00`;
+    } else {
+      timeLeft = `0:${timeLeft}`;
+    }
+    return timeLeft;
   }
 
   /**
    * get remaining time with timeunit
    *
    * @memberof TimerCountdown
-   * @return string
+   * @return string - seconds left
    */
   get remainingTime() {
     const unitOfTime = 'minute';
-    let timeLeft = Math.round(this.secondsLeftOnLoan);
-
-    // convert time from second to minute
-    timeLeft = Math.ceil(timeLeft / 60);
+    const timeLeft = this.minutesLeftOnLoan;
 
     return timeLeft !== 1
       ? `${timeLeft} ${unitOfTime}s`
@@ -36,58 +47,28 @@ export default class TimerCountdown extends LitElement {
   }
 
   render() {
+    const viewClass = this.displayTime ? 'view' : 'hide';
     return html`
-      <svg
-        width="14"
-        height="14"
-        viewBox="0 0 100 100"
-        xmlns="http://www.w3.org/2000/svg"
+      <button
+        id="timer-counter"
+        class=${viewClass}
+        @click=${() => {
+          this.displayTime = !this.displayTime;
+        }}
+        role="timer"
       >
-        <circle class="circle" cx="50" cy="50" r="50" />
-      </svg>
-      <span class="sr-only">${this.remainingTime} left</span>
+        <span>${this.minutesLeftOnLoan}</span>
+        <span class="sr-only">${this.remainingTime} left</span>
+      </button>
     `;
   }
 
   static get styles() {
-    const white = css`var(--white, #fff)`;
-    const timerSecondsLeft = css`var(--secondsLeftOnLoan, 6000s)`; //
-    const timerStrokeLeft = css`var(--strokeLeftOnLoan, 315)`;
-
     return css`
       :host {
         right: 0;
         margin-right: 10px;
         position: absolute;
-        height: 20px;
-        width: 20px;
-      }
-
-      @keyframes circletimer {
-        0% {
-          stroke-dashoffset: ${timerStrokeLeft};
-          stroke-dasharray: 315;
-        }
-        100% {
-          stroke-dashoffset: 0;
-          stroke-dasharray: 315;
-        }
-      }
-
-      svg {
-        background-color: ${white};
-        border-radius: 50px;
-        border: 2px solid ${white};
-        transform: rotateZ(-90deg);
-      }
-
-      svg .circle {
-        stroke: #000;
-        stroke-width: 100px;
-        fill: ${white};
-        stroke-dashoffset: 315;
-        stroke-dasharray: 0;
-        animation: ${timerSecondsLeft} circletimer linear;
       }
 
       .sr-only {
@@ -99,6 +80,18 @@ export default class TimerCountdown extends LitElement {
         padding: 0;
         border: none;
         overflow: hidden;
+      }
+
+      button#timer-counter {
+        cursor: pointer;
+      }
+
+      .hide {
+        opacity: 0;
+      }
+
+      .show {
+        opacity: 1;
       }
     `;
   }

--- a/src/core/config/constants.js
+++ b/src/core/config/constants.js
@@ -6,4 +6,4 @@ export const mobileContainerWidth = 700;
 /**
  * shift the actions buttons in dropdown
  */
-export const tabletContainerWidth = 895;
+export const tabletContainerWidth = 800;

--- a/src/core/config/ia-lending-intervals.js
+++ b/src/core/config/ia-lending-intervals.js
@@ -56,6 +56,6 @@ window.IALendingIntervals = {
   clearAll: () => {
     window?.IALendingIntervals?.clearTokenPoller();
     window?.IALendingIntervals?.clearTimerCountdown();
-    window.IALendingIntervals.clearBrowseExpireTimeout();
+    window?.IALendingIntervals?.clearBrowseExpireTimeout();
   },
 };

--- a/src/core/config/ia-lending-intervals.js
+++ b/src/core/config/ia-lending-intervals.js
@@ -1,3 +1,4 @@
+/* global: window */
 /**
  * Collection of methods for managing intervals for lending system
  *
@@ -18,16 +19,19 @@ window.IALendingIntervals = {
   tokenPoller: 0,
 
   /**
-   * store timer-countdown interval
-   * @see TimerCountdown::timerCountdown
+   * renewal check interval
    */
   timerCountdown: 0,
+
+  /** expiration timer */
+  browseExpireTimeout: 0,
 
   /**
    * clear interval for create_token api
    */
   clearTokenPoller: () => {
-    window.clearInterval(window?.IALendingIntervals?.tokenPoller);
+    window.clearInterval(window.IALendingIntervals.tokenPoller);
+    window.IALendingIntervals.tokenPoller = 0;
   },
 
   /**
@@ -35,13 +39,23 @@ window.IALendingIntervals = {
    */
   clearTimerCountdown: () => {
     window.clearInterval(window.IALendingIntervals.timerCountdown);
+    window.IALendingIntervals.timerCountdown = 0;
+  },
+
+  /**
+   * clear interval for graphic timer for one-hour loan renew
+   */
+  clearBrowseExpireTimeout: () => {
+    window.clearTimeout(window.IALendingIntervals.browseExpireTimeout);
+    window.IALendingIntervals.browseExpireTimeout = 0;
   },
 
   /**
    * clear all intervals being used acros lending system
    */
   clearAll: () => {
-    window.clearInterval(window?.IALendingIntervals?.tokenPoller);
-    window.clearInterval(window?.IALendingIntervals?.timerCountdown);
+    window?.IALendingIntervals?.clearTokenPoller();
+    window?.IALendingIntervals?.clearTimerCountdown();
+    window.IALendingIntervals.clearBrowseExpireTimeout();
   },
 };

--- a/src/core/services/actions-handler/actions-handler-service.js
+++ b/src/core/services/actions-handler/actions-handler-service.js
@@ -21,7 +21,7 @@ export default async function ActionsHandlerService(options) {
   const tokenError = 'loan token not found. please try again later.';
   const borrowError =
     'This book is not available to borrow at this time. Please try again later.';
-  const erroneousActions = ['browse_book', 'borrow_book', 'create_token'];
+  const erroneousActions = ['browse_book', 'borrow_book', 'create_token', 'renew_loan'];
   const shouldReturnError =
     location?.href?.indexOf('?error=true') !== -1 &&
     location?.hostname !== 'archive.org';

--- a/src/core/services/actions-handler/actions-handler-service.js
+++ b/src/core/services/actions-handler/actions-handler-service.js
@@ -21,7 +21,12 @@ export default async function ActionsHandlerService(options) {
   const tokenError = 'loan token not found. please try again later.';
   const borrowError =
     'This book is not available to borrow at this time. Please try again later.';
-  const erroneousActions = ['browse_book', 'borrow_book', 'create_token', 'renew_loan'];
+  const erroneousActions = [
+    'browse_book',
+    'borrow_book',
+    'create_token',
+    'renew_loan',
+  ];
   const shouldReturnError =
     location?.href?.indexOf('?error=true') !== -1 &&
     location?.hostname !== 'archive.org';
@@ -36,7 +41,7 @@ export default async function ActionsHandlerService(options) {
       method: 'POST',
       body: formData,
     })
-      .then(response => {
+      .then(async response => {
         // intentional error on localhost
         if (shouldReturnError && erroneousActions.includes(option?.action)) {
           return {
@@ -48,6 +53,8 @@ export default async function ActionsHandlerService(options) {
         // return success response for /demo/ server...
         if (baseHost == '/demo/1' || baseHost == '/demo/') {
           if (option?.action == 'renew_loan') {
+            // wait a few seconds so that the user can see the loading state
+            await new Promise(resolve => setTimeout(resolve, 5000));
             return {
               success: true,
               loan: { renewal: true },

--- a/src/core/services/actions-handler/actions-handler-service.js
+++ b/src/core/services/actions-handler/actions-handler-service.js
@@ -26,6 +26,7 @@ export default async function ActionsHandlerService(options) {
     'borrow_book',
     'create_token',
     'renew_loan',
+    'return_loan',
   ];
   const shouldReturnError =
     location?.href?.indexOf('?error=true') !== -1 &&
@@ -52,7 +53,10 @@ export default async function ActionsHandlerService(options) {
 
         // return success response for /demo/ server...
         if (baseHost == '/demo/1' || baseHost == '/demo/') {
-          if (option?.action == 'renew_loan') {
+          if (
+            option?.action == 'renew_loan' ||
+            option?.action == 'return_loan'
+          ) {
             // wait a few seconds so that the user can see the loading state
             await new Promise(resolve => setTimeout(resolve, 5000));
             return {

--- a/src/core/services/actions-handler/actions-handler.js
+++ b/src/core/services/actions-handler/actions-handler.js
@@ -142,6 +142,13 @@ export default class ActionsHandler extends LitElement {
       action,
       identifier: this.identifier,
       success: data => {
+        console.log(
+          'RENEW_LOAN --- ',
+          data,
+          action,
+          data.loan,
+          this.identifier
+        );
         if (data?.success === true && data?.loan?.renewal === true) {
           this.setBrowseTimeSession();
           this.dispatchEvent(

--- a/src/core/services/actions-handler/actions-handler.js
+++ b/src/core/services/actions-handler/actions-handler.js
@@ -7,10 +7,6 @@ import log from '../log.js';
 import ActionsHandlerService from './actions-handler-service.js';
 import LoanAnanlytics from '../loan-analytics.js';
 import * as Cookies from '../doc-cookies.js';
-import {
-  analyticsCategories,
-  analyticsActions,
-} from '../../config/analytics-event-and-category.js';
 
 /**
  * These are callback functions calling from actions-config.js file.
@@ -46,10 +42,6 @@ export default class ActionsHandler extends LitElement {
     this.addEventListener('browseBook', async () => {
       this.handleBrowseIt();
       await this.loanAnanlytics?.storeLoanStatsCount(this.identifier, 'browse');
-      this.loanAnanlytics?.sendEvent(
-        analyticsCategories.browse,
-        analyticsActions.browse
-      );
     });
 
     this.addEventListener('browseBookAgain', async () => {
@@ -57,10 +49,6 @@ export default class ActionsHandler extends LitElement {
       await this.loanAnanlytics?.storeLoanStatsCount(
         this.identifier,
         'browseagain'
-      );
-      this.loanAnanlytics?.sendEvent(
-        analyticsCategories.browse,
-        analyticsActions.browseBookAgain
       );
     });
 
@@ -70,10 +58,6 @@ export default class ActionsHandler extends LitElement {
         this.identifier,
         'autorenew'
       );
-      this.loanAnanlytics?.sendEvent(
-        analyticsCategories.browse,
-        analyticsActions.browseAutoRenew
-      );
     });
 
     this.addEventListener('autoReturn', async () => {
@@ -81,14 +65,6 @@ export default class ActionsHandler extends LitElement {
       await this.loanAnanlytics?.storeLoanStatsCount(
         this.identifier,
         'autoreturn'
-      );
-      await this.loanAnanlytics?.storeLoanStatsCount(
-        this.identifier,
-        'autorenew'
-      );
-      this.loanAnanlytics?.sendEvent(
-        analyticsCategories.browse,
-        analyticsActions.browseAutoReturn
       );
     });
 

--- a/src/core/services/actions-handler/actions-handler.js
+++ b/src/core/services/actions-handler/actions-handler.js
@@ -7,6 +7,10 @@ import log from '../log.js';
 import ActionsHandlerService from './actions-handler-service.js';
 import LoanAnanlytics from '../loan-analytics.js';
 import * as Cookies from '../doc-cookies.js';
+import {
+  analyticsCategories,
+  analyticsActions,
+} from '../../config/analytics-event-and-category.js';
 
 /**
  * These are callback functions calling from actions-config.js file.
@@ -39,24 +43,53 @@ export default class ActionsHandler extends LitElement {
   }
 
   bindEvents() {
-    this.addEventListener('browseBook', () => {
+    this.addEventListener('browseBook', async () => {
       this.handleBrowseIt();
-      this.loanAnanlytics?.storeLoanStatsCount(this.identifier, 'browse');
+      await this.loanAnanlytics?.storeLoanStatsCount(this.identifier, 'browse');
+      this.loanAnanlytics?.sendEvent(
+        analyticsCategories.browse,
+        analyticsActions.browse
+      );
     });
 
-    this.addEventListener('browseBookAgain', () => {
+    this.addEventListener('browseBookAgain', async () => {
       this.handleBrowseIt();
-      this.loanAnanlytics?.storeLoanStatsCount(this.identifier, 'browseagain');
+      await this.loanAnanlytics?.storeLoanStatsCount(
+        this.identifier,
+        'browseagain'
+      );
+      this.loanAnanlytics?.sendEvent(
+        analyticsCategories.browse,
+        analyticsActions.browseBookAgain
+      );
     });
 
-    this.addEventListener('autoRenew', () => {
+    this.addEventListener('autoRenew', async () => {
       this.handleLoanRenewNow();
-      this.loanAnanlytics?.storeLoanStatsCount(this.identifier, 'autorenew');
+      await this.loanAnanlytics?.storeLoanStatsCount(
+        this.identifier,
+        'autorenew'
+      );
+      this.loanAnanlytics?.sendEvent(
+        analyticsCategories.browse,
+        analyticsActions.browseAutoRenew
+      );
     });
 
-    this.addEventListener('autoReturn', () => {
+    this.addEventListener('autoReturn', async () => {
       this.handleReturnIt();
-      this.loanAnanlytics?.storeLoanStatsCount(this.identifier, 'autoreturn');
+      await this.loanAnanlytics?.storeLoanStatsCount(
+        this.identifier,
+        'autoreturn'
+      );
+      await this.loanAnanlytics?.storeLoanStatsCount(
+        this.identifier,
+        'autorenew'
+      );
+      this.loanAnanlytics?.sendEvent(
+        analyticsCategories.browse,
+        analyticsActions.browseAutoReturn
+      );
     });
 
     this.addEventListener('returnNow', ({ detail }) => {

--- a/src/core/services/actions-handler/actions-handler.js
+++ b/src/core/services/actions-handler/actions-handler.js
@@ -299,6 +299,7 @@ export default class ActionsHandler extends LitElement {
    * set browse time in indexedDB
    */
   async setBrowseTimeSession() {
+    // TODO: USE loan info to determine what we have left
     try {
       const expireDate = new Date(
         new Date().getTime() + this.loanTotalTime * 1000

--- a/src/core/services/actions-handler/actions-handler.js
+++ b/src/core/services/actions-handler/actions-handler.js
@@ -2,6 +2,7 @@ import { LitElement } from 'lit';
 
 import { URLHelper } from '../../config/url-helper.js';
 import { sentryLogs } from '../../config/sentry-events.js';
+import log from '../log.js';
 
 import ActionsHandlerService from './actions-handler-service.js';
 import LoanAnanlytics from '../loan-analytics.js';
@@ -142,13 +143,7 @@ export default class ActionsHandler extends LitElement {
       action,
       identifier: this.identifier,
       success: data => {
-        console.log(
-          'RENEW_LOAN --- ',
-          data,
-          action,
-          data.loan,
-          this.identifier
-        );
+        log('RENEW_LOAN --- ', data, action, data.loan, this.identifier);
         if (data?.success === true && data?.loan?.renewal === true) {
           this.setBrowseTimeSession();
           this.dispatchEvent(
@@ -322,7 +317,7 @@ export default class ActionsHandler extends LitElement {
       // delete pageChangedTime when book is auto renew at nth minute
       await this.localCache.delete(`${this.identifier}-pageChangedTime`);
     } catch (error) {
-      console.log(error);
+      log(error);
     }
   }
 

--- a/src/core/services/get-lending-actions.js
+++ b/src/core/services/get-lending-actions.js
@@ -40,7 +40,7 @@ import ActionsConfig from './actions-config.js';
  * @enum {string}
  */
 export const bookTitles = {
-  available_1hr: 'Renews automatically as long as pages are turned.',
+  available_1hr: 'Renews automatically with continued use.',
   available_14d: 'This book can be borrowed for 14 days.',
   available_pd: 'Book available to patrons with print disabilities.',
   available_waitlist: 'A waitlist is available.',
@@ -49,7 +49,7 @@ export const bookTitles = {
   being_borrowed: 'Another patron is using this book. Please check back later.',
   eligible_pd: 'You are eligible for print-disabled access.',
   on_waitlist: 'You are on the waitlist for this book.',
-  session_expired: 'Renews automatically as long as pages are turned.',
+  session_expired: 'Renews automatically with continued use.',
   unavailable: 'This book is not available at this time.',
 };
 

--- a/src/core/services/loan-analytics.js
+++ b/src/core/services/loan-analytics.js
@@ -2,6 +2,7 @@
 
 import { analyticsCategories } from '../config/analytics-event-and-category.js';
 import * as Cookies from './doc-cookies.js';
+import log from './log.js';
 
 /**
  * This class is used to send different GA events for loan system.
@@ -45,7 +46,7 @@ export default class LoanAnanlytics {
         '/'
       );
     } catch (error) {
-      console.log(error);
+      log(error);
       this.sendEvent('Cookies-Error-Actions', error, this.identifier);
     }
   }
@@ -144,7 +145,7 @@ export default class LoanAnanlytics {
    * @memberof LoanAnanlytics
    */
   sendEvent(eventCategory, eventAction, label, extraParams) {
-    // console.log(
+    // log(
     //   'eventCategory:-',
     //   eventCategory,
     //   '\t||\teventAction:-',

--- a/src/core/services/loan-renew-helper.js
+++ b/src/core/services/loan-renew-helper.js
@@ -1,6 +1,7 @@
 /* eslint-disable class-methods-use-this */
 
 import { nothing } from 'lit';
+import log from './log.js';
 
 /**
  * This class is used to determine if use is eligible for auto renew loan.
@@ -32,7 +33,7 @@ export class LoanRenewHelper {
       }
       return this.autoChecker(); // auto checker at last 10th minute
     } catch (error) {
-      console.log(error);
+      log(error);
     }
 
     return nothing;

--- a/src/core/services/loan-token-poller.js
+++ b/src/core/services/loan-token-poller.js
@@ -1,3 +1,4 @@
+/* global: window */
 import ActionsHandlerService from './actions-handler/actions-handler-service.js';
 import LoanAnanlytics from './loan-analytics.js';
 import { sentryLogs } from '../config/sentry-events.js';

--- a/src/core/services/log.js
+++ b/src/core/services/log.js
@@ -1,0 +1,16 @@
+/* eslint-disable no-restricted-globals */
+/* eslint-disable semi */
+/**
+ * log() utility -- production ignores 'log()' JS calls; dev invokes 'log()'
+ */
+const log =
+  location.hostname === 'localhost' ||
+  location.host.match(/^(www|cat)-[a-z0-9]+\.archive\.org$/) ||
+  location.host.match(/\.code\.archive\.org$/) ||
+  location.host.match(/\.dev\.archive\.org$/) ||
+  location.host.match(/^ia-petabox-/)
+    ? // eslint-disable-next-line no-console
+      console.log.bind(console) // convenient, no?  Stateless function
+    : () => {};
+
+export { log as default };

--- a/src/ia-book-actions.js
+++ b/src/ia-book-actions.js
@@ -631,16 +631,16 @@ export default class IABookActions extends LitElement {
     if (this.loanRenewResult.renewNow) {
       window?.IALendingIntervals?.clearAll();
 
+      // Now, let's reset loan duration & this.lendingStatus
+      const loanTime = await this.localCache.get(`${this.identifier}-loanTime`);
+      const secondsLeft = (loanTime - new Date()) / 1000; // different in seconds
+
       // testing console....
       log('IABookActions: AutoRenewed:- ', {
         ajaxResponse: event?.detail?.data,
         loanRenewResult: this.loanRenewResult,
-        secondsLeftOnLoan: Math.round(this.lendingStatus.secondsLeftOnLoan), // stale? how to fix
+        secondsLeftOnLoan: secondsLeft,
       });
-
-      // Now, let's reset loan duration & this.lendingStatus
-      const loanTime = await this.localCache.get(`${this.identifier}-loanTime`);
-      const secondsLeft = (loanTime - new Date()) / 1000; // different in seconds
 
       const currStatus = {
         ...this.lendingStatus,

--- a/src/ia-book-actions.js
+++ b/src/ia-book-actions.js
@@ -281,13 +281,6 @@ export default class IABookActions extends LitElement {
         this.autoLoanRenewChecker(true);
       }
     });
-
-    window.focus(() => {
-      log('WINDOW FOCUS', this.borrowType);
-      if (this.borrowType === 'browsed') {
-        this.autoLoanRenewChecker(true);
-      }
-    });
   }
 
   /**
@@ -450,8 +443,6 @@ export default class IABookActions extends LitElement {
    * Show modal when book is auto returned
    */
   async showExpiredModal() {
-    log('showExpiredModal()');
-
     const config = new ModalConfig({
       headline: '',
       showCloseButton: false,
@@ -566,14 +557,8 @@ export default class IABookActions extends LitElement {
       secondsLeftOnLoan,
     } = this.lendingStatus;
 
-    log('startBrowseTimerstartBrowseTimer just cleared timer', {
-      browsingExpired,
-      user_has_browsed,
-      secondsLeftOnLoan,
-    });
-
     if (!user_has_browsed || browsingExpired) {
-      log('user not browsed', {
+      log('startBrowseTimer --- !user_has_browsed || browsingExpired', {
         user_has_browsed,
         browsingExpired,
         secondsLeftOnLoan,
@@ -583,7 +568,7 @@ export default class IABookActions extends LitElement {
 
     window.IALendingIntervals.browseExpireTimeout = setTimeout(() => {
       log(
-        'start `this.browseTimer will fire his.browseHasExpired() - secondsLeftOnLoan',
+        'startBrowseTimer > browseExpireTimeout --- will expire loan',
         secondsLeftOnLoan
       );
       this.browseHasExpired();
@@ -658,8 +643,7 @@ export default class IABookActions extends LitElement {
       const loanTime = await this.localCache.get(`${this.identifier}-loanTime`);
       const secondsLeft = Math.round((loanTime - new Date()) / 1000); // different in seconds
 
-      // testing console....
-      log('~~~ IABookActions: handleLoanAutoRenewed:- ', {
+      log('IABookActions: handleLoanAutoRenewed --- ', {
         ajaxResponse: event?.detail?.data,
         loanRenewResult: this.loanRenewResult,
         secondsLeftOnLoan: secondsLeft,
@@ -702,13 +686,13 @@ export default class IABookActions extends LitElement {
       const resync = await this.reSyncTimerIfGoneOff(secondsLeft);
 
       if (resync) {
-        log('timer has resyncd, abort stale startTimerCountdown - ', {
+        log('startTimerCountdown --- stale, timer has resyncd', {
           secondsLeft,
         });
         return;
       }
 
-      log('startTimerCountdown - countdown still valid. continue...', {
+      log('startTimerCountdown --- countdown still valid. continue...', {
         resync,
         secondsLeft,
         loanRenewAtLast: this.loanRenewTimeConfig.loanRenewAtLast,
@@ -771,7 +755,7 @@ export default class IABookActions extends LitElement {
     }
 
     if (whatIsleft !== whatShouldLeft) {
-      log(`timer is gone off, let's re-sync,`);
+      log(`reSyncTimerIfGoneOff --- let's re-sync.`);
 
       return true;
     }
@@ -787,7 +771,10 @@ export default class IABookActions extends LitElement {
    * @memberof IABookActions
    */
   async loanRenewAttempt(secondsLeft) {
-    log('loanRenewAttempt()', secondsLeft, this.loanRenewResult);
+    log('loanRenewAttempt ---', {
+      secondsLeft,
+      loanRenewResult: this.loanRenewResult,
+    });
     let loanSecondsLeft = secondsLeft;
     /**
      * auto-renew is not possible in last seconds (let say 50 second) because,
@@ -797,7 +784,7 @@ export default class IABookActions extends LitElement {
      * so if seconds left is < 50, just expire the loan
      */
     if (loanSecondsLeft < 50) {
-      log('if (loanSecondsLeft < 50) {');
+      log('loanRenewAttempt --- loanSecondsLeft < 50, will expire');
       await this.browseHasExpired();
       return;
     }

--- a/src/ia-book-actions.js
+++ b/src/ia-book-actions.js
@@ -6,6 +6,7 @@ import { SharedResizeObserver } from '@internetarchive/shared-resize-observer';
 import { ModalConfig } from '@internetarchive/modal-manager';
 import { ToastConfig } from '@internetarchive/toast-manager';
 import { LocalCache } from '@internetarchive/local-cache';
+import '@internetarchive/ia-activity-indicator';
 
 import './components/collapsible-action-group.js';
 import './components/book-title-bar.js';

--- a/src/ia-book-actions.js
+++ b/src/ia-book-actions.js
@@ -257,6 +257,9 @@ export default class IABookActions extends LitElement {
     // initial timer state for 1-hour loan
     if (this.borrowType === 'browsed' && !this.loanRenewResult.renewNow) {
       setTimeout(() => {
+        console.log(
+          'IN TIMEOUT OF --- setupLendingToolbarActions, firing resetTimerCountState'
+        );
         this.resetTimerCountState();
       }, 100);
     }
@@ -511,6 +514,11 @@ export default class IABookActions extends LitElement {
 
   async startBrowseTimer() {
     clearTimeout(this.browseTimer);
+    console.log(
+      'startBrowseTimerstartBrowseTimer just cleared timer',
+      this.browseTimer,
+      this.lendingStatus
+    );
 
     const {
       browsingExpired,
@@ -523,6 +531,10 @@ export default class IABookActions extends LitElement {
     }
 
     this.browseTimer = setTimeout(() => {
+      console.log(
+        'start `this.browseTimer will fire his.browseHasExpired() - secondsLeftOnLoan',
+        secondsLeftOnLoan
+      );
       this.browseHasExpired();
     }, secondsLeftOnLoan * 1000);
   }

--- a/src/ia-book-actions.js
+++ b/src/ia-book-actions.js
@@ -640,14 +640,21 @@ export default class IABookActions extends LitElement {
    * - reset timer state
    * @param {object} event
    */
-  async handleLoanAutoRenewed(event) {
+  async handleLoanAutoRenewed({ detail }) {
+    const activeLoan = detail?.data?.loan;
+    const errorMessage = `Whoops, seems we hit a hiccup with renewing this book. Please refresh & retry. --- (Debug: ${detail?.data?.error})`;
+    if (!activeLoan) {
+      this.showErrorModal(errorMessage, 'handleLoanAutoRenewed');
+      return;
+    }
+
     if (this.loanRenewResult.renewNow) {
       // Now, let's reset loan duration & this.lendingStatus
       const loanTime = await this.localCache.get(`${this.identifier}-loanTime`);
       const secondsLeft = Math.round((loanTime - new Date()) / 1000); // different in seconds
 
       log('IABookActions: handleLoanAutoRenewed --- ', {
-        ajaxResponse: event?.detail?.data,
+        ajaxResponse: detail?.data,
         loanRenewResult: this.loanRenewResult,
         secondsLeftOnLoan: secondsLeft,
       });

--- a/src/ia-book-actions.js
+++ b/src/ia-book-actions.js
@@ -301,11 +301,14 @@ export default class IABookActions extends LitElement {
     this.loanRenewResult = this.loanRenewHelper.result;
   }
 
-  /** @returns HTMLElement */
+  /**
+   * Required as sibling on page
+   * @returns HTMLElement
+   */
   get modal() {
-    const modalOnDom = document.querySelector('modal-manager');
+    const modalOnDom = document.body.querySelector('modal-manager');
 
-    modalOnDom.id = 'action-bar-modal';
+    modalOnDom?.setAttribute('id', 'action-bar-modal');
     return modalOnDom;
   }
 

--- a/src/ia-book-actions.js
+++ b/src/ia-book-actions.js
@@ -221,6 +221,8 @@ export default class IABookActions extends LitElement {
       'browsingExpired' in this.lendingStatus &&
       this.lendingStatus?.browsingExpired;
     if (hasExpired) {
+      log('setupLendingToolbarActions > hasExpired --- ');
+
       if (!this.tokenPoller) {
         window?.Sentry?.captureMessage(sentryLogs.bookWasExpired);
       }
@@ -525,6 +527,7 @@ export default class IABookActions extends LitElement {
    * Execute when loan is expired
    */
   async browseHasExpired() {
+    log('BrowseHasExpired ---');
     window?.IALendingIntervals?.clearAll();
 
     const currStatus = {

--- a/src/ia-book-actions.js
+++ b/src/ia-book-actions.js
@@ -149,7 +149,6 @@ export default class IABookActions extends LitElement {
   updated(changed) {
     if (changed.has('lendingStatus') || changed.has('bwbPurchaseUrl')) {
       this.setupLendingToolbarActions();
-      this.update();
     }
 
     if (changed.has('sharedObserver')) {
@@ -255,6 +254,8 @@ export default class IABookActions extends LitElement {
     setTimeout(() => {
       if (!hasExpired) this.startLoanTokenPoller();
     }, 100);
+
+    this.requestUpdate();
   }
 
   /**

--- a/src/ia-book-actions.js
+++ b/src/ia-book-actions.js
@@ -71,7 +71,7 @@ export default class IABookActions extends LitElement {
     this.identifier = '';
     this.bookTitle = '';
     this.returnUrl = '';
-    this.lendingStatus = {};
+    this.lendingStatus = {}; // very important as components feed from this
     this.width = 0;
     this.bwbPurchaseUrl = '';
     this.lendingBarPostInit = () => {};
@@ -86,8 +86,8 @@ export default class IABookActions extends LitElement {
     this.primaryColor = 'primary';
     this.secondaryActions = [];
     this.lendingOptions = {};
-    this.borrowType = null; // (browsed|borrowed)
-    this.browseTimer = undefined;
+    this.borrowType = null; // 'browsed'|'borrowed'
+    this.browseTimer = undefined; // timeout
     this.timerExecutionSeconds = 30;
 
     /** @deprecated */

--- a/src/ia-book-actions.js
+++ b/src/ia-book-actions.js
@@ -20,6 +20,7 @@ import { sentryLogs } from './core/config/sentry-events.js';
 import { LoanTokenPoller } from './core/services/loan-token-poller.js';
 import { LoanRenewHelper } from './core/services/loan-renew-helper.js';
 import log from './core/services/log.js';
+import { URLHelper } from './core/config/url-helper.js';
 
 export const events = {
   browseExpired: 'IABookReader:BrowsingHasExpired',
@@ -458,7 +459,7 @@ export default class IABookActions extends LitElement {
         <button
           style="${modalButtonStyle.iaButton} ${modalButtonStyle.renew}"
           @click=${() => {
-            window.location?.reload();
+            URLHelper.goToUrl(this.returnUrl, true);
           }}
         >
           Okay

--- a/src/ia-book-actions.js
+++ b/src/ia-book-actions.js
@@ -123,10 +123,10 @@ export default class IABookActions extends LitElement {
     this.loanRenewResult = { texts: '', renewNow: false, secondsLeft: 0 };
 
     /**
-     * need showdowRoot opened for resetTimerCountState
-     * @see IABookActions::resetTimerCountState
-     */
-    this._shadowRoot = this.attachShadow({ mode: 'open' });
+    //  * need showdowRoot opened for resetTimerCountState
+    //  * @see IABookActions::resetTimerCountState
+    //  */
+    // this._shadowRoot = this.attachShadow({ mode: 'open' });
   }
 
   disconnectedCallback() {
@@ -252,16 +252,6 @@ export default class IABookActions extends LitElement {
     if (!this.borrowType || this.barType === 'title') {
       this.lendingBarPostInit();
       return;
-    }
-
-    // initial timer state for 1-hour loan
-    if (this.borrowType === 'browsed' && !this.loanRenewResult.renewNow) {
-      setTimeout(() => {
-        log(
-          'IN TIMEOUT OF --- setupLendingToolbarActions, firing resetTimerCountState'
-        );
-        this.resetTimerCountState();
-      }, 100);
     }
 
     /**
@@ -567,46 +557,6 @@ export default class IABookActions extends LitElement {
     }, secondsLeftOnLoan * 1000);
   }
 
-  /**
-   * Reset timer animation state after book renewed
-   */
-  async resetTimerCountState() {
-    const timerCountdown = this._shadowRoot.querySelector('timer-countdown');
-    if (!timerCountdown) return;
-
-    const secondsLeft = Number.parseInt(
-      Number(this.lendingStatus.secondsLeftOnLoan),
-      10
-    );
-    const firstStrokeDashOffset = Number.parseInt(
-      (secondsLeft / this.loanRenewTimeConfig.loanTotalTime) * 315 * 1.5,
-      10
-    );
-    const actualStrokeDashOffset =
-      firstStrokeDashOffset > 315 ? 315 : firstStrokeDashOffset;
-
-    log('resetTimerCountState === ', {
-      secondsLeft,
-      firstStrokeDashOffset,
-      actualStrokeDashOffset,
-    });
-
-    // set seconds left in loan expire
-    timerCountdown.style?.setProperty('--secondsLeftOnLoan', `${secondsLeft}s`);
-
-    // set circle stroke offset left in loan expire
-    timerCountdown.style?.setProperty(
-      '--strokeLeftOnLoan',
-      `${actualStrokeDashOffset}` // the perimeter of the circle = (π * 2 * radius)
-    );
-
-    const animationCircle = timerCountdown.shadowRoot.querySelector('.circle');
-    animationCircle.style.animationName = 'none';
-    setTimeout(() => {
-      animationCircle.style.animationName = 'circletimer';
-    }, 100);
-  }
-
   render() {
     if (this.barType === 'title') {
       return html`<section class="lending-wrapper">
@@ -652,7 +602,6 @@ export default class IABookActions extends LitElement {
       ${this.textGroupTemplate} ${this.infoIconTemplate}
       <timer-countdown
         .secondsLeftOnLoan=${Number(this.lendingStatus.secondsLeftOnLoan)}
-        class=${this.borrowType === 'browsed' ? '' : 'hide'}
       ></timer-countdown>
     `;
   }
@@ -690,9 +639,6 @@ export default class IABookActions extends LitElement {
       log('~~~ handleLoanAutoRenewed - new this.lendingStatus', {
         secondsLeftOnLoan: this.lendingStatus.secondsLeftOnLoan,
       });
-
-      /** reset timer */
-      await this.resetTimerCountState();
 
       // close the modal
       this.modal?.closeModal();

--- a/src/ia-book-actions.js
+++ b/src/ia-book-actions.js
@@ -547,18 +547,19 @@ export default class IABookActions extends LitElement {
   }
 
   async startBrowseTimer() {
-    clearTimeout(this.browseTimer);
+    window.IALendingIntervals.clearBrowseExpireTimeout();
+
     const {
       browsingExpired,
       user_has_browsed,
       secondsLeftOnLoan,
     } = this.lendingStatus;
 
-    log(
-      'startBrowseTimerstartBrowseTimer just cleared timer',
-      this.browseTimer,
-      { browsingExpired, user_has_browsed, secondsLeftOnLoan }
-    );
+    log('startBrowseTimerstartBrowseTimer just cleared timer', {
+      browsingExpired,
+      user_has_browsed,
+      secondsLeftOnLoan,
+    });
 
     if (!user_has_browsed || browsingExpired) {
       log('user not browsed', {
@@ -569,7 +570,7 @@ export default class IABookActions extends LitElement {
       return;
     }
 
-    this.browseTimer = setTimeout(() => {
+    window.IALendingIntervals.browseExpireTimeout = setTimeout(() => {
       log(
         'start `this.browseTimer will fire his.browseHasExpired() - secondsLeftOnLoan',
         secondsLeftOnLoan

--- a/src/ia-book-actions.js
+++ b/src/ia-book-actions.js
@@ -334,6 +334,7 @@ export default class IABookActions extends LitElement {
 
     const config = new ModalConfig({
       headline: 'Are you still here?',
+      headerColor: '#194880',
       showCloseButton: false,
       closeOnBackdropClick: false,
       message: this.loanRenewHelper?.getMessageTexts(
@@ -381,6 +382,7 @@ export default class IABookActions extends LitElement {
 
     const config = new ModalConfig({
       headline: 'Are you still here?',
+      headerColor: '#194880',
       showCloseButton: false,
       closeOnBackdropClick: false,
       message: this.loanRenewHelper?.getMessageTexts(
@@ -434,6 +436,7 @@ export default class IABookActions extends LitElement {
       headline: '',
       showCloseButton: false,
       closeOnBackdropClick: false,
+      headerColor: '#194880',
       message: 'This book has been returned due to inactivity.',
     });
 

--- a/src/ia-book-actions.js
+++ b/src/ia-book-actions.js
@@ -333,7 +333,7 @@ export default class IABookActions extends LitElement {
     }
 
     const config = new ModalConfig({
-      headline: 'Are you still here?',
+      headline: 'Are you still reading?',
       headerColor: '#194880',
       showCloseButton: false,
       closeOnBackdropClick: false,
@@ -350,16 +350,13 @@ export default class IABookActions extends LitElement {
       >
         <button
           style="${modalButtonStyle.iaButton} ${modalButtonStyle.renew}"
-          @click=${event => this.patronWantsToRenewBook(event)}
+          @click=${() => this.patronWantsToRenewBook()}
         >
           Keep reading
         </button>
         <button
           style="${modalButtonStyle.iaButton} ${modalButtonStyle.return}"
-          @click=${() => {
-            document.querySelector('ia-book-actions').disableActionGroup = true;
-            this.returnNow = true;
-          }}
+          @click=${() => this.patronWantsToReturnBook()}
         >
           Return the book
         </button>
@@ -369,7 +366,8 @@ export default class IABookActions extends LitElement {
     await this.modal?.showModal({ config, customModalContent });
   }
 
-  async showWarningDisabledModal() {
+  /** @param { 'renewBook' | 'returnBook' } buttonToDisable */
+  async showWarningDisabledModal(buttonToDisable = 'renewBook') {
     log('****** showWarningDisabledModal ******');
 
     // if secondsLeft < 60, consider it 1 minute
@@ -381,7 +379,7 @@ export default class IABookActions extends LitElement {
     }
 
     const config = new ModalConfig({
-      headline: 'Are you still here?',
+      headline: 'Are you still reading?',
       headerColor: '#194880',
       showCloseButton: false,
       closeOnBackdropClick: false,
@@ -400,10 +398,12 @@ export default class IABookActions extends LitElement {
           disabled
           style="${modalButtonStyle.iaButton} ${modalButtonStyle.renew}"
         >
-          <ia-activity-indicator
-            mode="processing"
-            style=${modalButtonStyle.loaderIcon}
-          ></ia-activity-indicator>
+          ${buttonToDisable === 'renewBook'
+            ? html`<ia-activity-indicator
+                mode="processing"
+                style=${modalButtonStyle.loaderIcon}
+              ></ia-activity-indicator>`
+            : 'Keep reading'}
         </button>
         <span
           style="position: absolute; visibility: none; height: 1px; width: 1px; overflow: hidden;"
@@ -413,7 +413,12 @@ export default class IABookActions extends LitElement {
           disabled
           style="${modalButtonStyle.iaButton} ${modalButtonStyle.return}"
         >
-          Return the book
+          ${buttonToDisable === 'returnBook'
+            ? html`<ia-activity-indicator
+                mode="processing"
+                style=${modalButtonStyle.loaderIcon}
+              ></ia-activity-indicator>`
+            : 'Return the book'}
         </button>
       </div> `;
 
@@ -424,6 +429,12 @@ export default class IABookActions extends LitElement {
   async patronWantsToRenewBook() {
     this.showWarningDisabledModal();
     this.loanRenewResult = { texts: '', renewNow: true };
+  }
+
+  async patronWantsToReturnBook() {
+    this.showWarningDisabledModal('returnBook');
+    document.querySelector('ia-book-actions').disableActionGroup = true;
+    this.returnNow = true;
   }
 
   /**

--- a/src/ia-book-actions.js
+++ b/src/ia-book-actions.js
@@ -433,12 +433,6 @@ export default class IABookActions extends LitElement {
     this.showWarningDisabledModal('returnBook');
     document.querySelector('ia-book-actions').disableActionGroup = true;
     this.returnNow = true;
-
-    this.lendingStatus = {
-      ...this.lendingStatus,
-      browsingExpired: true,
-      secondsLeftOnLoan: 0,
-    };
   }
 
   /**
@@ -552,7 +546,7 @@ export default class IABookActions extends LitElement {
   }
 
   async startBrowseTimer() {
-    window.IALendingIntervals.clearBrowseExpireTimeout();
+    window?.IALendingIntervals?.clearBrowseExpireTimeout();
 
     const {
       browsingExpired,

--- a/src/ia-book-actions.js
+++ b/src/ia-book-actions.js
@@ -6,7 +6,6 @@ import { SharedResizeObserver } from '@internetarchive/shared-resize-observer';
 import { ModalConfig } from '@internetarchive/modal-manager';
 import { ToastConfig } from '@internetarchive/toast-manager';
 import { LocalCache } from '@internetarchive/local-cache';
-import '@internetarchive/ia-activity-indicator';
 
 import './components/collapsible-action-group.js';
 import './components/book-title-bar.js';
@@ -414,6 +413,10 @@ export default class IABookActions extends LitElement {
             style=${modalButtonStyle.loaderIcon}
           ></ia-activity-indicator>
         </button>
+        <span
+          style="position: absolute; visibility: none; height: 1px; width: 1px; overflow: hidden;"
+          >Renewing loan, one moment please.</span
+        >
         <button
           disabled
           style="${modalButtonStyle.iaButton} ${modalButtonStyle.return}"

--- a/src/ia-book-actions.js
+++ b/src/ia-book-actions.js
@@ -323,7 +323,7 @@ export default class IABookActions extends LitElement {
     // clear modal
     this.modal.customModalContent = nothing;
     this.modal?.closeModal();
-    console.log("MODAL CLOSED ___ ", this.modal.customModalContent);
+    console.log('MODAL CLOSED ___ ', this.modal.customModalContent);
     this.loanRenewResult = { texts: '', renewNow: false };
 
     // if secondsLeft < 60, consider it 1 minute
@@ -341,11 +341,14 @@ export default class IABookActions extends LitElement {
       message: this.loanRenewHelper?.getMessageTexts(
         this.loanRenewResult.texts,
         secondsLeft
-      )
+      ),
     });
 
     const customModalContent = html`<br />
-      <div id="book-action-bar-custom-buttons" style="display:flex;justify-content:center;">
+      <div
+        id="book-action-bar-custom-buttons"
+        style="display:flex;justify-content:center;"
+      >
         <button
           style="${modalButtonStyle.iaButton} ${modalButtonStyle.renew}"
           @click=${event => this.patronWantsToRenewBook(event)}
@@ -355,7 +358,6 @@ export default class IABookActions extends LitElement {
         <button
           style="${modalButtonStyle.iaButton} ${modalButtonStyle.return}"
           @click=${() => {
-            // this.changeModalState(event);
             document.querySelector('ia-book-actions').disableActionGroup = true;
             this.returnNow = true;
           }}
@@ -363,7 +365,6 @@ export default class IABookActions extends LitElement {
           Return the book
         </button>
       </div> `;
-
 
     await this.modal?.showModal({ config, customModalContent });
   }
@@ -386,28 +387,29 @@ export default class IABookActions extends LitElement {
       message: this.loanRenewHelper?.getMessageTexts(
         this.loanRenewResult.texts,
         secondsLeft
-      )
+      ),
     });
 
+    // this doesn't really work? shows empty button
 
-        // this doesn't really work? shows empty button
+    // if (event.target === undefined) return;
 
-        // if (event.target === undefined) return;
+    // const button = event.target;
+    // button.disabled = true;
+    // button.innerHTML = `<ia-activity-indicator
+    //   mode="processing"
+    //   style=${modalButtonStyle.loaderIcon}
+    // ></ia-activity-indicator>`;
 
-        // const button = event.target;
-        // button.disabled = true;
-        // button.innerHTML = `<ia-activity-indicator
-        //   mode="processing"
-        //   style=${modalButtonStyle.loaderIcon}
-        // ></ia-activity-indicator>`;
-    
-        // const parentElement = event.target.parentNode;
-        // parentElement.style.pointerEvents = 'none';
-        // parentElement.style.opacity = 0.8;
-
+    // const parentElement = event.target.parentNode;
+    // parentElement.style.pointerEvents = 'none';
+    // parentElement.style.opacity = 0.8;
 
     const customModalContent = html`<br />
-      <div id="disabled-book-action-bar-custom-buttons" style="display:flex;justify-content:center; opacity:0.8; pointer-events:none;">
+      <div
+        id="disabled-book-action-bar-custom-buttons"
+        style="display:flex;justify-content:center; opacity:0.8; pointer-events:none;"
+      >
         <button
           disabled
           style="${modalButtonStyle.iaButton} ${modalButtonStyle.renew}"
@@ -428,38 +430,10 @@ export default class IABookActions extends LitElement {
     await this.modal?.showModal({ config, customModalContent });
   }
 
-  
-
-  async patronWantsToRenewBook(event) {
-    // this.changeModalState(event);
-    console.log("patron wants to renew book!!!!", this.loanRenewResult);
-    this.loanRenewResult = { texts: '', renewNow: true };
-    console.log("patron wants to renew book!!!! loanRenewResult set as: ", this.loanRenewResult);
-  }
-
-  /**
-   * helper function to change button click states on modal-manager
-   * - add loader on button click
-   * - change button appearance
-   *
-   * @param {Event} event
-   */
-  changeModalState() {
+  /** Handles Renew action in warning modal */
+  async patronWantsToRenewBook() {
     this.showWarningDisabledModal();
-    // this doesn't really work? shows empty button
-
-    // if (event.target === undefined) return;
-
-    // const button = event.target;
-    // button.disabled = true;
-    // button.innerHTML = `<ia-activity-indicator
-    //   mode="processing"
-    //   style=${modalButtonStyle.loaderIcon}
-    // ></ia-activity-indicator>`;
-
-    // const parentElement = event.target.parentNode;
-    // parentElement.style.pointerEvents = 'none';
-    // parentElement.style.opacity = 0.8;
+    this.loanRenewResult = { texts: '', renewNow: true };
   }
 
   /**
@@ -472,7 +446,7 @@ export default class IABookActions extends LitElement {
       headline: '',
       showCloseButton: false,
       closeOnBackdropClick: false,
-      message: 'This book has been returned due to inactivity.'
+      message: 'This book has been returned due to inactivity.',
     });
 
     const customModalContent = html`<br />
@@ -732,7 +706,7 @@ export default class IABookActions extends LitElement {
       // }
       this.modal.customModalContent = nothing;
       this.modal?.closeModal();
-      console.log("MODAL CLOSED ___ ", this.modal.customModalContent);
+      console.log('MODAL CLOSED ___ ', this.modal.customModalContent);
 
       window?.Sentry?.captureMessage(sentryLogs.bookHasRenewed);
     }
@@ -970,7 +944,6 @@ export default class IABookActions extends LitElement {
 
   /* show error message if something went wrong */
   async showErrorModal(errorMsg, action) {
-
     const modalConfig = new ModalConfig({
       title: 'Lending error',
       message: errorMsg,

--- a/test/core/services/loan-token-poller.test.js
+++ b/test/core/services/loan-token-poller.test.js
@@ -1,11 +1,23 @@
 import { expect } from '@open-wc/testing';
 import Sinon from 'sinon';
 
-// import { LocalCache } from '@internetarchive/local-cache';
 import { LoanTokenPoller } from '../../../src/core/services/loan-token-poller.js';
+import '@internetarchive/modal-manager';
+
+beforeEach(async () => {
+  await import('../../../src/core/config/ia-lending-intervals.js');
+
+  const modalManager = document.createElement('modal-manager');
+  document.body.appendChild(modalManager);
+});
+
+afterEach(() => {
+  document.body.removeChild(document.querySelector('modal-manager'));
+});
 
 describe('Get Loan Token', () => {
   it('get loan token for browsed books', async () => {
+    // id, borrowType, successCallback, errorCallback, pollerDelay
     const tokenPoller = new LoanTokenPoller(
       'identifier1',
       'browsed',

--- a/test/ia-book-actions.test.js
+++ b/test/ia-book-actions.test.js
@@ -1,13 +1,19 @@
 import { html, fixture, expect, aTimeout } from '@open-wc/testing';
-
+import '@internetarchive/modal-manager';
 import '../src/ia-book-actions.js';
 import Sinon from 'sinon';
 
 import { SharedResizeObserver } from '@internetarchive/shared-resize-observer';
 import { LocalCache } from '@internetarchive/local-cache';
 
+beforeEach(() => {
+  const modalManager = document.createElement('modal-manager');
+  document.body.appendChild(modalManager);
+});
+
 afterEach(() => {
   Sinon.restore();
+  document.body.removeChild(document.querySelector('modal-manager'));
 });
 
 // localCache used for auto-loan-renew
@@ -15,11 +21,17 @@ const localCache = new LocalCache({
   namespace: 'loanRenew',
 });
 
-const container = ({ userid, identifier, lendingStatus = {} } = {}) =>
+const container = ({
+  userid,
+  identifier,
+  lendingStatus = {},
+  barType = 'action',
+} = {}) =>
   html`<ia-book-actions
     .userid=${userid}
     .identifier=${identifier}
     .lendingStatus=${lendingStatus}
+    .barType=${barType}
   ></ia-book-actions>`;
 
 describe('<ia-book-actions>', () => {
@@ -38,6 +50,36 @@ describe('<ia-book-actions>', () => {
 
     expect(el.userid).to.be.equal('@user1');
     expect(el.identifier).to.equal('foobar');
+  });
+
+  it('Can daw a title bar instead of actions', async () => {
+    const el = await fixture(
+      container({
+        userid: '@user1',
+        identifier: 'foobar',
+        barType: 'title',
+      })
+    );
+
+    const titleBar = el.shadowRoot.querySelector('book-title-bar');
+    expect(titleBar).to.exist;
+  });
+
+  it('Handles <collapsible-action-group>@toggleActionGroup event', async () => {
+    const el = await fixture(
+      container({
+        userid: '@user1',
+        identifier: 'foobar',
+      })
+    );
+
+    const collapsibleActionGroup = el.shadowRoot.querySelector(
+      'collapsible-action-group'
+    );
+    expect(el.disableActionGroup).to.be.false;
+    collapsibleActionGroup.dispatchEvent(new Event('toggleActionGroup'));
+    await el.updateComplete;
+    expect(el.disableActionGroup).to.be.true;
   });
 });
 
@@ -269,8 +311,7 @@ describe('Browsing expired status', () => {
 
     expect(el.primaryActions[0].text).to.equal('Borrow');
 
-    // timer-countdown is gone now
-    expect(el.shadowRoot.querySelector('timer-countdown')).to.be.null;
+    expect(el.shadowRoot.querySelector('timer-countdown')).to.exist;
 
     //   // book has been expired
     expect(el.loanRenewResult.renewNow).to.equal(false);
@@ -318,6 +359,7 @@ describe('Browsing expired status', () => {
 
 describe('Auto renew one hour loan', () => {
   it('Book is browsing and renewed it now', async () => {
+    const loanTime = 88;
     const el = await fixture(
       container({
         userid: '@userid',
@@ -326,37 +368,69 @@ describe('Auto renew one hour loan', () => {
           is_lendable: true,
           user_has_browsed: true,
           browseHasExpired: false,
-          secondsLeftOnLoan: 12,
+          secondsLeftOnLoan: loanTime,
         },
       })
     );
 
+    // timer-countdown starts with same amount component is loaded with
+    expect(
+      el.shadowRoot.querySelector('timer-countdown').secondsLeftOnLoan
+    ).to.equal(loanTime);
+
+    const handleLoanAutoRenewedSpy = Sinon.spy(el, 'handleLoanAutoRenewed');
+
+    // let's update state, fastforward loan...
     el.loanRenewResult = {
       texts: 'This book has been renewed for 1 hour.',
       renewNow: true,
       secondsLeft: 10,
     };
+    el.lendingStatus = {
+      is_lendable: true,
+      user_has_browsed: true,
+      browseHasExpired: false,
+      secondsLeftOnLoan: 8, // <-- loan time has decreased
+    };
+
+    await el.updateComplete;
 
     await localCache.set({
       key: `${el.identifier}-loanTime`,
-      value: new Date(new Date().getTime() + 10 * 1000),
+      value: new Date(new Date().getTime() + loanTime * 1000),
       ttl: Number(10),
     });
 
-    const myEvent = new CustomEvent('loanAutoRenewed');
-    el.addEventListener('loanAutoRenewed', () => {
-      el.handleLoanAutoRenewed();
-    });
-    el.dispatchEvent(myEvent);
+    // timer-countdown reflects decreased loan time
+    expect(
+      el.shadowRoot.querySelector('timer-countdown').secondsLeftOnLoan
+    ).to.equal(8);
+
+    // dispatch loanAutoRenewed event - test 200 callback
+    const collapsibleActionGroupEl = el.shadowRoot.querySelector(
+      'collapsible-action-group'
+    );
+    collapsibleActionGroupEl.dispatchEvent(
+      new CustomEvent('loanAutoRenewed', {
+        detail: { data: { identifier: 'Foo' } },
+      })
+    );
 
     await aTimeout(1900); // wait for 1.9 second
     await el.updateComplete;
+
+    // Autorenew 200 callback is called
+    expect(handleLoanAutoRenewedSpy.calledOnce).to.equal(true);
 
     expect(el.loanRenewResult.texts).to.equal(
       'This book has been renewed for 1 hour.'
     );
     expect(el.loanRenewResult.renewNow).to.equal(true);
     expect(el.loanRenewResult.secondsLeft).to.equal(10);
+    expect(el.shadowRoot.querySelector('timer-countdown')).to.exist;
+    expect(
+      el.shadowRoot.querySelector('timer-countdown').secondsLeftOnLoan
+    ).to.equal(loanTime);
   });
 });
 

--- a/test/ia-book-actions.test.js
+++ b/test/ia-book-actions.test.js
@@ -189,7 +189,7 @@ describe('Borrow status actions', () => {
     ];
 
     expect(el.primaryTitle).to.equal(
-      'Renews automatically as long as pages are turned.'
+      'Renews automatically with continued use.'
     );
     expect(el.primaryActions.length).to.equal(2);
     expect(el.primaryActions[0].text).to.equal('Log In and Borrow');

--- a/test/ia-book-actions.test.js
+++ b/test/ia-book-actions.test.js
@@ -81,6 +81,25 @@ describe('<ia-book-actions>', () => {
     await el.updateComplete;
     expect(el.disableActionGroup).to.be.true;
   });
+
+  it('handles `BookReader:userAction` event', async () => {
+    const el = await fixture(
+      container({
+        userid: '@user1',
+        identifier: 'foobar',
+      })
+    );
+
+    const spy = Sinon.spy(el, 'autoLoanRenewChecker');
+    el.borrowType = 'browsed';
+    await el.updateComplete;
+
+    window.dispatchEvent(new Event('BookReader:userAction'));
+    await el.updateComplete;
+
+    expect(spy.calledOnce).to.be.true;
+    expect(spy.calledWith(true)).to.be.true;
+  });
 });
 
 describe('Primary Actions data', () => {
@@ -304,14 +323,14 @@ describe('Browsing expired status', () => {
     );
 
     // timer-countdown is still active
-    expect(el.shadowRoot.querySelector('timer-countdown')).to.not.be.null;
+    expect(el.timerCountdownEl).to.exist;
 
     await aTimeout(1500); // wait for 1.5 second
     await el.updateComplete;
 
     expect(el.primaryActions[0].text).to.equal('Borrow');
 
-    expect(el.shadowRoot.querySelector('timer-countdown')).to.exist;
+    expect(el.timerCountdownEl).to.exist;
 
     //   // book has been expired
     expect(el.loanRenewResult.renewNow).to.equal(false);
@@ -374,9 +393,7 @@ describe('Auto renew one hour loan', () => {
     );
 
     // timer-countdown starts with same amount component is loaded with
-    expect(
-      el.shadowRoot.querySelector('timer-countdown').secondsLeftOnLoan
-    ).to.equal(loanTime);
+    expect(el.timerCountdownEl.secondsLeftOnLoan).to.equal(loanTime);
 
     const handleLoanAutoRenewedSpy = Sinon.spy(el, 'handleLoanAutoRenewed');
 
@@ -402,9 +419,9 @@ describe('Auto renew one hour loan', () => {
     });
 
     // timer-countdown reflects decreased loan time
-    expect(
-      el.shadowRoot.querySelector('timer-countdown').secondsLeftOnLoan
-    ).to.equal(8);
+    expect(el.timerCountdownEl.secondsLeftOnLoan).to.equal(8);
+
+    expect(el.postInitComplete).to.equal(33);
 
     // dispatch loanAutoRenewed event - test 200 callback
     const collapsibleActionGroupEl = el.shadowRoot.querySelector(
@@ -427,10 +444,8 @@ describe('Auto renew one hour loan', () => {
     );
     expect(el.loanRenewResult.renewNow).to.equal(true);
     expect(el.loanRenewResult.secondsLeft).to.equal(10);
-    expect(el.shadowRoot.querySelector('timer-countdown')).to.exist;
-    expect(
-      el.shadowRoot.querySelector('timer-countdown').secondsLeftOnLoan
-    ).to.equal(loanTime);
+    expect(el.timerCountdownEl).to.exist;
+    expect(el.timerCountdownEl.secondsLeftOnLoan).to.equal(loanTime);
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,23 +10,23 @@
     "@babel/highlight" "^7.10.4"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.11":
-  version "7.16.7"
-  resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz"
-  integrity sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==
+  version "7.21.4"
+  resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.21.4.tgz"
+  integrity sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==
   dependencies:
-    "@babel/highlight" "^7.16.7"
+    "@babel/highlight" "^7.18.6"
 
-"@babel/helper-validator-identifier@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz"
-  integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
+"@babel/helper-validator-identifier@^7.18.6":
+  version "7.19.1"
+  resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz"
+  integrity sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==
 
-"@babel/highlight@^7.10.4", "@babel/highlight@^7.16.7":
-  version "7.16.10"
-  resolved "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz"
-  integrity sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==
+"@babel/highlight@^7.10.4", "@babel/highlight@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz"
+  integrity sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.16.7"
+    "@babel/helper-validator-identifier" "^7.18.6"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
@@ -76,7 +76,7 @@
 
 "@internetarchive/ia-activity-indicator@^0.0.4":
   version "0.0.4"
-  resolved "https://registry.yarnpkg.com/@internetarchive/ia-activity-indicator/-/ia-activity-indicator-0.0.4.tgz#22fa19b072e4084799cf4c71ab73e4973c2670c3"
+  resolved "https://registry.npmjs.org/@internetarchive/ia-activity-indicator/-/ia-activity-indicator-0.0.4.tgz"
   integrity sha512-nJFs3uAnPyDLqtkEVV4vMD1dli+eOyovd5rY/un9nOahu2elTHOHrIfNH0YvBkLXR7C9GVCeI9H8BD8BXq+rhg==
   dependencies:
     lit "^2.2.2"
@@ -111,14 +111,14 @@
 
 "@internetarchive/local-cache@^0.2.1":
   version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@internetarchive/local-cache/-/local-cache-0.2.1.tgz#fa416cae81227228b73f51d82f3361d460e27539"
+  resolved "https://registry.npmjs.org/@internetarchive/local-cache/-/local-cache-0.2.1.tgz"
   integrity sha512-8FFAvEEoazktWsIEod2NVYp0r+Fk3OxM8woe42mNlXHbht3Je98yQjooIFiA3/sJYB7xsZB2RHzUzh+GmBHFgw==
   dependencies:
     idb-keyval "^6.1.0"
 
 "@internetarchive/modal-manager@^0.2.12":
   version "0.2.12"
-  resolved "https://registry.yarnpkg.com/@internetarchive/modal-manager/-/modal-manager-0.2.12.tgz#e25eadcaf9e5720ae4e13fadfed67382f67b1c88"
+  resolved "https://registry.npmjs.org/@internetarchive/modal-manager/-/modal-manager-0.2.12.tgz"
   integrity sha512-9n6fx8kz0TSUCSroemEzznuNtMiTchfVzXkbvueTRLOjNXFMePUl5dmQ376KRcfJZSCBdbMKIgsT383C9I95Tw==
   dependencies:
     "@internetarchive/ia-activity-indicator" "^0.0.4"
@@ -135,7 +135,7 @@
 
 "@internetarchive/toast-manager@0.1.0":
   version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@internetarchive/toast-manager/-/toast-manager-0.1.0.tgz#d7801ee87fab0de3a67e97a0b385a6656e7a583a"
+  resolved "https://registry.npmjs.org/@internetarchive/toast-manager/-/toast-manager-0.1.0.tgz"
   integrity sha512-bsKjd+TBtnTzY2XlTLccFdyL2bGPgpqtUxYxkXeRdsqGa7n9QKw0IFFAYITJu2UCxU46kk43r6x8TE7/nQRc4g==
   dependencies:
     lit "^2.2.7"
@@ -582,7 +582,7 @@
 
 "@types/yauzl@^2.9.1":
   version "2.10.0"
-  resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.10.0.tgz#b3248295276cf8c6f153ebe6a9aba0c988cb2599"
+  resolved "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz"
   integrity sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==
   dependencies:
     "@types/node" "*"
@@ -2113,7 +2113,7 @@ fs.realpath@^1.0.0:
 
 fsevents@~2.3.1, fsevents@~2.3.2:
   version "2.3.2"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 function-bind@^1.1.1:


### PR DESCRIPTION
### Fixes:

- Warning Modal updates
  - blue header
  - new text, "Are you still reading?"
  - loading interstitial when options are clicked (cleaned up stale states)
- Demo updates:
  - can show warning modal from demo
  - can show expired modal from demo
- Timer countdown updates
  - no more pie
  - can toggle easter egg timer view at right side of book actions bar
  - move expire timeout to global space
- tablet size update to make space between info icon & hidden button
- new log.js file so no console.logs leak out into production
- Analytics calls for new actions
- caveats: Global assumptions (for better esm loading)
  - modal-manager is required on page (already drawn by details.inc, imported by details-bookreader.js)
  - ia-activity-indicator is peer dependency (loaded via ia-book-theater) 


