### PR TITLE
Declare lit ^2.8.0 || ^3.3.2 dual range (WEBDEV-8374)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "deploy:gh": "gh-pages -t -d ghpages -m \"Build for $(git log --pretty=format:\"%h %an %ai %s\" -n1) [skip ci]\""
   },
   "dependencies": {
-    "@internetarchive/icon-info": "1.3.5",
+    "@internetarchive/icon-info": "^1.4.1",
     "@internetarchive/local-cache": "^0.2.1",
     "@internetarchive/modal-manager": "^2.0.0",
     "@internetarchive/shared-resize-observer": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@internetarchive/modal-manager": "^2.0.0",
     "@internetarchive/shared-resize-observer": "^0.2.0",
     "install-deps": "^1.1.0",
-    "lit": "^2.8.0"
+    "lit": "^2.8.0 || ^3.3.2"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -232,12 +232,12 @@
   dependencies:
     lit "^2.0.2 || ^3.0.0"
 
-"@internetarchive/icon-info@1.3.5":
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/@internetarchive/icon-info/-/icon-info-1.3.5.tgz#f4d73d47b51527dec4afdb85b68dec8ba233aedd"
-  integrity sha512-SF16eO0Hzmga22ixnUjYuKm7TGAKxXI91ms2s+kogVhcg1YlwBGjlc5KhANz0mhRGkrTFMEBybaV2sZpvF74KQ==
+"@internetarchive/icon-info@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@internetarchive/icon-info/-/icon-info-1.4.1.tgz#e0cb1d9a4dc7a319554614387cd057b37e1b742a"
+  integrity sha512-lxb0K996QA+tpJKqKNHpV+3aSXmLKxfXisHcPfcoGCXxYzPYDqyk6XlcPj3h1H80XgqRk1pWRsHBykOvCui2ZA==
   dependencies:
-    lit "^2.0.2"
+    lit "^2.0.2 || ^3.0.0"
 
 "@internetarchive/icon-user@^1.4.0":
   version "1.4.1"
@@ -3343,14 +3343,6 @@ listr2@^3.2.2:
     through "^2.3.8"
     wrap-ansi "^7.0.0"
 
-lit-element@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.npmjs.org/lit-element/-/lit-element-3.2.0.tgz"
-  integrity sha512-HbE7yt2SnUtg5DCrWt028oaU4D5F4k/1cntAFHTkzY8ZIa8N0Wmu92PxSxucsQSOXlODFrICkQ5x/tEshKi13g==
-  dependencies:
-    "@lit/reactive-element" "^1.3.0"
-    lit-html "^2.2.0"
-
 lit-element@^3.3.0:
   version "3.3.3"
   resolved "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz"
@@ -3376,13 +3368,6 @@ lit-element@^4.2.0:
   dependencies:
     "@types/trusted-types" "^2.0.2"
 
-lit-html@^2.2.0:
-  version "2.2.1"
-  resolved "https://registry.npmjs.org/lit-html/-/lit-html-2.2.1.tgz"
-  integrity sha512-AiJ/Rs0awjICs2FioTnHSh+Np5dhYSkyRczKy3wKjp8qjLhr1Ov+GiHrUQNdX8ou1LMuznpIME990AZsa/tR8g==
-  dependencies:
-    "@types/trusted-types" "^2.0.2"
-
 lit-html@^2.8.0:
   version "2.8.0"
   resolved "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz"
@@ -3398,15 +3383,6 @@ lit-html@^2.8.0:
     "@lit/reactive-element" "^2.1.0"
     lit-element "^4.2.0"
     lit-html "^3.3.0"
-
-lit@^2.0.2:
-  version "2.2.1"
-  resolved "https://registry.npmjs.org/lit/-/lit-2.2.1.tgz"
-  integrity sha512-dSe++R50JqrvNGXmI9OE13de1z5U/Y3J2dTm/9GC86vedI8ILoR8ZGnxfThFpvQ9m0lR0qRnIR4IiKj/jDCfYw==
-  dependencies:
-    "@lit/reactive-element" "^1.3.0"
-    lit-element "^3.2.0"
-    lit-html "^2.2.0"
 
 lit@^2.8.0:
   version "2.8.0"


### PR DESCRIPTION
## Summary

Two-line `package.json` change closing out the `iaux-book-actions` Lit 2/3 migration:

1. `lit: "^2.8.0"` → `"^2.8.0 || ^3.3.2"` (dual-range, mirrors `modal-manager@2.0.5`).
2. `@internetarchive/icon-info: "1.3.5"` → `"^1.4.1"` (now that `icon-info@1.4.1` is published with `lit: ^2.0.2 || ^3.0.0` instead of the broken Lit-1 `1.4.0`).

## Diff

```diff
   "dependencies": {
-    "@internetarchive/icon-info": "1.3.5",
+    "@internetarchive/icon-info": "^1.4.1",
     "@internetarchive/local-cache": "^0.2.1",
     "@internetarchive/modal-manager": "^2.0.0",
     "@internetarchive/shared-resize-observer": "^0.2.0",
     "install-deps": "^1.1.0",
-    "lit": "^2.8.0"
+    "lit": "^2.8.0 || ^3.3.2"
   },
```

## Resulting tree (`npm ls lit lit-html @lit/reactive-element --omit=dev`)

| Package | Resolved Lit |
| --- | --- |
| `iaux-book-actions` (this) | **lit@3.3.2** |
| `@internetarchive/modal-manager@2.0.5` | lit@3.3.2 *(deduped)* |
| `@internetarchive/icon-close@1.4.1` | lit@3.3.2 *(deduped)* |
| `@internetarchive/icon-user@1.4.1` | lit@3.3.2 *(deduped)* |
| `@internetarchive/icon-info@1.4.1` | lit@3.3.2 *(deduped)* — **new in this PR** |
| `@internetarchive/ia-activity-indicator@0.0.6` | lit@2.8.0 *(separate, upstream pin)* |

After this PR, only `ia-activity-indicator` keeps a separate Lit 2 subtree. That's tracked in [WEBDEV-8384](https://webarchive.jira.com/browse/WEBDEV-8384) → [iaux#1003](https://github.com/internetarchive/iaux/pull/1003); once that lands and publishes, the entire tree collapses to a single Lit 3.

## Test plan

- [x] `yarn install` clean (only the pre-existing `@open-wc/eslint-config@4.2.0` peer-dep warnings)
- [x] `npx web-test-runner --playwright --browsers chromium` — **40/40 tests pass** (4.4s)
- [x] `npm ls lit lit-html @lit/reactive-element --omit=dev` — verified the dedupe pattern shown above
- [ ] Reviewer: confirm CI is green
- [ ] Downstream check (offshoot): once a new `iaux-book-actions` is published, `yarn dedupe` / `npm dedupe` should collapse `lit@3.x` to a single resolved copy across `iaux-book-actions` and offshoot's own `lit`

## Migration umbrella status (after this PR + #87 + #88 + iaux#1003)

- [x] [WEBDEV-8373](https://webarchive.jira.com/browse/WEBDEV-8373) — test-stack bump (#87, merged)
- [x] [WEBDEV-8382](https://webarchive.jira.com/browse/WEBDEV-8382) — modal-manager unpin (#88, merged)
- [x] icon-close@1.4.1 / icon-user@1.4.1 / icon-info@1.4.1 — published
- [ ] [WEBDEV-8374](https://webarchive.jira.com/browse/WEBDEV-8374) — lit dual range + icon-info bump *(this PR)*
- [ ] [WEBDEV-8384](https://webarchive.jira.com/browse/WEBDEV-8384) — ia-activity-indicator dual range ([iaux#1003](https://github.com/internetarchive/iaux/pull/1003))

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WEBDEV-8384]: https://webarchive.jira.com/browse/WEBDEV-8384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ