### PR TITLE
v1.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "author": "Internet Archive",
   "license": "AGPL-3.0-only",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "main": "index.js",
   "module": "index.js",
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -218,12 +218,12 @@
   resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz"
   integrity sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==
 
-"@internetarchive/ia-activity-indicator@^0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@internetarchive/ia-activity-indicator/-/ia-activity-indicator-0.0.6.tgz#46bc71620b3a7630f18bc0b8e883a52443af1016"
-  integrity sha512-Llut9sdsmmVqgxASqSlCqoiXSNb4M7xWY3/O7QUh3NnuR7WMfAcYBqNRDsLve7t/VkbVVBOVyeVAROnjvYHGNQ==
+"@internetarchive/ia-activity-indicator@^0.0.6 || ^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@internetarchive/ia-activity-indicator/-/ia-activity-indicator-1.0.0.tgz#9067093c037f81b2ff05747324449876afbb9643"
+  integrity sha512-vBwWGDBb/vzB+jxwLFeOjzmwXWD+UjAqvQFTszwQ31hEMBBY0U+jgSgMDznt/3pb1e8ZcqtzsHRTvpKkzhoZsg==
   dependencies:
-    lit "^2.8.0"
+    lit "^2.8.0 || ^3.3.2"
 
 "@internetarchive/icon-close@^1.4.0":
   version "1.4.1"
@@ -254,11 +254,11 @@
     idb-keyval "^6.1.0"
 
 "@internetarchive/modal-manager@^2.0.0":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@internetarchive/modal-manager/-/modal-manager-2.0.5.tgz#33dd708cb66e352dabe6bb12afe0c85f6aaa48f6"
-  integrity sha512-u4Qtslp2T03KMAshSHe45RxHs/rBUQCCjNXIXL4wKEPcdqj0K/gyNSz3F/eMqxf2TutHLewCtnXOmS7W42xwxA==
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@internetarchive/modal-manager/-/modal-manager-2.0.6.tgz#8d13fec07b2adfe4752733e12d39e888244ca8f4"
+  integrity sha512-PDEXz005tgjhKxrJLnd1sn8wn3DceEQqDluDhcn8+gxxhFKX714jyicKlbgvHzQOLtJYTdJjnNdmiyziF7ZIVA==
   dependencies:
-    "@internetarchive/ia-activity-indicator" "^0.0.6"
+    "@internetarchive/ia-activity-indicator" "^0.0.6 || ^1.0.0"
     "@internetarchive/icon-close" "^1.4.0"
     "@internetarchive/icon-user" "^1.4.0"
     lit "^2.8.0 || ^3.3.2"
@@ -287,32 +287,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@lit-labs/ssr-dom-shim@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.0.0.tgz"
-  integrity sha512-ic93MBXfApIFTrup4a70M/+ddD8xdt2zxxj9sRwHQzhS9ag/syqkD8JPdTXsc1gUy2K8TTirhlCqyTEM/sifNw==
-
-"@lit-labs/ssr-dom-shim@^1.1.0":
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.0.tgz"
-  integrity sha512-yWJKmpGE6lUURKAaIltoPIE/wrbY3TEkqQt+X0m+7fQNnAv0keydnYvbiJFP1PnMhizmIWRWOG5KLhYyc/xl+g==
-
 "@lit-labs/ssr-dom-shim@^1.5.0":
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz#3166900c0d481f03d6d4133686e0febf760d521d"
   integrity sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==
-
-"@lit/reactive-element@^1.3.0":
-  version "1.3.1"
-  resolved "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.3.1.tgz"
-  integrity sha512-nOJARIr3pReqK3hfFCSW2Zg/kFcFsSAlIE7z4a0C9D2dPrgD/YSn3ZP2ET/rxKB65SXyG7jJbkynBRm+tGlacw==
-
-"@lit/reactive-element@^1.6.0":
-  version "1.6.1"
-  resolved "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.1.tgz"
-  integrity sha512-va15kYZr7KZNNPZdxONGQzpUr+4sxVu7V/VG7a8mRfPPXUyhEYj5RzXCQmGrlP3tAh0L3HHm5AjBMFYRqlM9SA==
-  dependencies:
-    "@lit-labs/ssr-dom-shim" "^1.0.0"
 
 "@lit/reactive-element@^2.1.0":
   version "2.1.2"
@@ -831,9 +809,9 @@
   integrity sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==
 
 "@types/trusted-types@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz"
-  integrity sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
 
 "@types/ws@^7.4.0":
   version "7.4.0"
@@ -3343,15 +3321,6 @@ listr2@^3.2.2:
     through "^2.3.8"
     wrap-ansi "^7.0.0"
 
-lit-element@^3.3.0:
-  version "3.3.3"
-  resolved "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz"
-  integrity sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==
-  dependencies:
-    "@lit-labs/ssr-dom-shim" "^1.1.0"
-    "@lit/reactive-element" "^1.3.0"
-    lit-html "^2.8.0"
-
 lit-element@^4.2.0:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-4.2.2.tgz#f74fcbfbea945eae5614ece22a674fa52ca3365b"
@@ -3368,13 +3337,6 @@ lit-element@^4.2.0:
   dependencies:
     "@types/trusted-types" "^2.0.2"
 
-lit-html@^2.8.0:
-  version "2.8.0"
-  resolved "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz"
-  integrity sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==
-  dependencies:
-    "@types/trusted-types" "^2.0.2"
-
 "lit@^2.0.0 || ^3.0.0", "lit@^2.0.2 || ^3.0.0", "lit@^2.8.0 || ^3.3.2", lit@^3.0.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/lit/-/lit-3.3.2.tgz#d9230ebbf237bfd3d2091bc0b56c576a470ac4d7"
@@ -3383,15 +3345,6 @@ lit-html@^2.8.0:
     "@lit/reactive-element" "^2.1.0"
     lit-element "^4.2.0"
     lit-html "^3.3.0"
-
-lit@^2.8.0:
-  version "2.8.0"
-  resolved "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz"
-  integrity sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==
-  dependencies:
-    "@lit/reactive-element" "^1.6.0"
-    lit-element "^3.3.0"
-    lit-html "^2.8.0"
 
 load-json-file@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Summary

Release bundle for the [WEBDEV-8364](https://webarchive.jira.com/browse/WEBDEV-8364) Lit 2/3 migration umbrella. Just bumps the version field + refreshes the lockfile to consume the new upstream package releases. **No source code or behavior changes.**

## What's in 1.4.2 (since 1.4.1)

| Ticket | Change |
| --- | --- |
| [WEBDEV-8373](https://webarchive.jira.com/browse/WEBDEV-8373) | `@open-wc/testing` v2 → v4, `@web/test-runner` v0.11 → v0.20 |
| [WEBDEV-8382](https://webarchive.jira.com/browse/WEBDEV-8382) | `modal-manager` exact pin → caret (`"2.0.0"` → `"^2.0.0"`) |
| [WEBDEV-8374](https://webarchive.jira.com/browse/WEBDEV-8374) | `lit` dual range (`"^2.8.0"` → `"^2.8.0 || ^3.3.2"`), `icon-info` (`"1.3.5"` → `"^1.4.1"`) |

Plus this PR's lockfile cascade pulling in:

| Package | from | to |
| --- | --- | --- |
| `@internetarchive/modal-manager` | 2.0.5 | **2.0.6** ([WEBDEV-8385](https://webarchive.jira.com/browse/WEBDEV-8385)) |
| `@internetarchive/ia-activity-indicator` | 0.0.6 | **1.0.0** ([WEBDEV-8384](https://webarchive.jira.com/browse/WEBDEV-8384)) |
| `@internetarchive/icon-close` | 1.4.0 | **1.4.1** ([WEBDEV-8365](https://webarchive.jira.com/browse/WEBDEV-8365)) |
| `@internetarchive/icon-user` | 1.4.0 | **1.4.1** ([WEBDEV-8366](https://webarchive.jira.com/browse/WEBDEV-8366)) |

## Resulting tree (`npm ls lit lit-html @lit/reactive-element --omit=dev`)

```
@internetarchive/ia-book-actions@1.4.2
├─ @internetarchive/icon-info@1.4.1            → lit@3.3.2 deduped
├─ @internetarchive/modal-manager@2.0.6
│  ├─ @internetarchive/ia-activity-indicator@1.0.0  → lit@3.3.2 deduped
│  ├─ @internetarchive/icon-close@1.4.1             → lit@3.3.2 deduped
│  └─ @internetarchive/icon-user@1.4.1              → lit@3.3.2 deduped
└─ lit@3.3.2
```

**Single Lit version across the entire runtime tree.** No more "Multiple Lit versions" warning, no more duplicate Lit subtree forced on consumers.

## Test plan

- [x] `yarn install` clean
- [x] `npx web-test-runner --playwright --browsers chromium` — **40/40 tests pass**
- [x] `npm ls lit lit-html @lit/reactive-element --omit=dev` — single Lit 3.3.2
- [ ] Reviewer: confirm CI is green
- [ ] Maintainer: `npm publish` after merge

## Migration umbrella status (after this PR + publish)

- [x] [WEBDEV-8373](https://webarchive.jira.com/browse/WEBDEV-8373) — test-stack bump
- [x] [WEBDEV-8382](https://webarchive.jira.com/browse/WEBDEV-8382) — modal-manager unpin
- [x] [WEBDEV-8365](https://webarchive.jira.com/browse/WEBDEV-8365) / [8366](https://webarchive.jira.com/browse/WEBDEV-8366) — icon-close/icon-user republished as 1.4.1
- [x] [WEBDEV-8384](https://webarchive.jira.com/browse/WEBDEV-8384) — ia-activity-indicator@1.0.0 published
- [x] [WEBDEV-8385](https://webarchive.jira.com/browse/WEBDEV-8385) — modal-manager@2.0.6 published with widened range
- [x] [WEBDEV-8374](https://webarchive.jira.com/browse/WEBDEV-8374) — book-actions lit dual range + icon-info bump
- [ ] **This PR + publish** — closes the umbrella

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WEBDEV-8364]: https://webarchive.jira.com/browse/WEBDEV-8364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEBDEV-8373]: https://webarchive.jira.com/browse/WEBDEV-8373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEBDEV-8382]: https://webarchive.jira.com/browse/WEBDEV-8382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEBDEV-8374]: https://webarchive.jira.com/browse/WEBDEV-8374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEBDEV-8385]: https://webarchive.jira.com/browse/WEBDEV-8385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEBDEV-8384]: https://webarchive.jira.com/browse/WEBDEV-8384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ