### PR TITLE
Remove unused install-deps dependency (WEBDEV-8391)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@internetarchive/local-cache": "^0.2.1",
     "@internetarchive/modal-manager": "^2.0.0",
     "@internetarchive/shared-resize-observer": "^0.2.0",
-    "install-deps": "^1.1.0",
     "lit": "^2.8.0 || ^3.3.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1279,11 +1279,6 @@ buffer-crc32@~0.2.3:
   resolved "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz"
   integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
 
-builtins@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz"
-  integrity sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==
-
 bytes@3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz"
@@ -1560,14 +1555,6 @@ cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
-
-d@1, d@^1.0.1, d@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/d/-/d-1.0.2.tgz"
-  integrity sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==
-  dependencies:
-    es5-ext "^0.10.64"
-    type "^2.7.2"
 
 data-uri-to-buffer@^6.0.2:
   version "6.0.2"
@@ -1861,33 +1848,6 @@ es-to-primitive@^1.2.1:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
-
-es5-ext@^0.10.35, es5-ext@^0.10.62, es5-ext@^0.10.64, es5-ext@~0.10.14, es5-ext@~0.10.46:
-  version "0.10.64"
-  resolved "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz"
-  integrity sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==
-  dependencies:
-    es6-iterator "^2.0.3"
-    es6-symbol "^3.1.3"
-    esniff "^2.0.1"
-    next-tick "^1.1.0"
-
-es6-iterator@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz"
-  integrity sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==
-  dependencies:
-    d "1"
-    es5-ext "^0.10.35"
-    es6-symbol "^3.1.1"
-
-es6-symbol@^3.1.1, es6-symbol@^3.1.3:
-  version "3.1.4"
-  resolved "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz"
-  integrity sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==
-  dependencies:
-    d "^1.0.2"
-    ext "^1.7.0"
 
 esbuild-android-64@0.14.54:
   version "0.14.54"
@@ -2252,24 +2212,6 @@ eslint@^7.32.0, eslint@^7.6.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-esniff@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz"
-  integrity sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==
-  dependencies:
-    d "^1.0.1"
-    es5-ext "^0.10.62"
-    event-emitter "^0.3.5"
-    type "^2.7.2"
-
-esniff@~1.1:
-  version "1.1.3"
-  resolved "https://registry.npmjs.org/esniff/-/esniff-1.1.3.tgz"
-  integrity sha512-SLBLpfE7xWgF/HbzhVuAwqnJDRqSCNZqcqaIMVm+f+PbTp1kFRWu6BuT83SATb4Tp+ovr+S+u7vDH7/UErAOkw==
-  dependencies:
-    d "^1.0.1"
-    es5-ext "^0.10.62"
-
 espree@^7.3.0, espree@^7.3.1:
   version "7.3.1"
   resolved "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz"
@@ -2323,14 +2265,6 @@ etag@^1.8.1:
   resolved "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
-event-emitter@^0.3.5:
-  version "0.3.5"
-  resolved "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz"
-  integrity sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
-
 events-universal@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/events-universal/-/events-universal-1.0.1.tgz#b56a84fd611b6610e0a2d0f09f80fdf931e2dfe6"
@@ -2367,13 +2301,6 @@ execa@^5.0.0:
     onetime "^5.1.2"
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
-
-ext@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz"
-  integrity sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==
-  dependencies:
-    type "^2.7.2"
 
 extract-zip@^2.0.1:
   version "2.0.1"
@@ -2482,14 +2409,6 @@ find-replace@^3.0.0:
   integrity sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==
   dependencies:
     array-back "^3.0.1"
-
-find-requires@^0.2.2:
-  version "0.2.4"
-  resolved "https://registry.npmjs.org/find-requires/-/find-requires-0.2.4.tgz"
-  integrity sha512-olqOq6aUynTkqgBc8Ip1Dfh9PxIECFa+ITdJ53dPv4Ep6rLKRHzj0TmFNi3SA2k9ExWwVoLqZxa81z5uagXMSw==
-  dependencies:
-    es5-ext "~0.10.46"
-    esniff "~1.1"
 
 find-up@^2.0.0, find-up@^2.1.0:
   version "2.1.0"
@@ -2881,14 +2800,6 @@ inherits@2.0.3:
   version "2.0.3"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
-
-install-deps@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/install-deps/-/install-deps-1.1.0.tgz"
-  integrity sha512-QpBNp/ke7WeawAuH7pgUQXCLRpwbUqkwZY1TIF3c/+3ZBAXldXX+q79LaWZgXPOwMxPaXFLrjZAlDuzYpmymtg==
-  dependencies:
-    builtins "^1.0.3"
-    find-requires "^0.2.2"
 
 internal-ip@^6.2.0:
   version "6.2.0"
@@ -3567,11 +3478,6 @@ netmask@^2.0.2:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/netmask/-/netmask-2.1.1.tgz#80043d265b53aa521b3bd01e8fcdf353f9e1e81e"
   integrity sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==
-
-next-tick@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz"
-  integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
 
 nise@^5.1.1:
   version "5.1.1"
@@ -4658,11 +4564,6 @@ type-is@^1.6.16:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.24"
-
-type@^2.7.2:
-  version "2.7.2"
-  resolved "https://registry.npmjs.org/type/-/type-2.7.2.tgz"
-  integrity sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==
 
 typed-query-selector@^2.12.1:
   version "2.12.2"


### PR DESCRIPTION
## Summary

- `install-deps` is a CLI tool for editor-driven `npm install`s, not a library — nothing in `src/`, `test/`, `index.js`, or `demo/` imports it, and no script invokes its binary.
- Added accidentally in [PR #69](https://github.com/internetarchive/iaux-book-actions/pull/69) (commit [`dda1e99`](https://github.com/internetarchive/iaux-book-actions/commit/dda1e9919a2c021338a827b2fbee85ef12ead1ef), 2024-06-19) alongside unrelated dep bumps.
- Lived under `dependencies` (not `devDependencies`), so every consumer (offshoot, etc.) pulled it plus its transitive chain — 13 packages, ~3.84 MB per `yarn why` — for no reason. Drop it and regenerate the lockfile.

## Diff

- `package.json`: -1 line (the `install-deps` entry).
- `yarn.lock`: -99 lines — entries removed: `install-deps`, `find-requires`, `builtins`, `esniff`, `d`, `es5-ext`, `es6-iterator`, `es6-symbol`, `event-emitter`, `ext`, `next-tick`, `type`. No source code changes.

## Test plan

- [x] `yarn why install-deps` → "We couldn't find a match!" (also `find-requires`, `builtins`).
- [x] `yarn install` clean.
- [ ] `yarn lint` — pre-existing prettier warning on `src/ia-book-actions.js` is unrelated and out of scope here.
- [ ] `yarn test:fast` — full suite green.
- [ ] `yarn start` — demo loads, borrow / return / renew flows behave as before.

## Jira

[WEBDEV-8391](https://webarchive.jira.com/browse/WEBDEV-8391) — Remove unused install-deps dependency from iaux-book-actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WEBDEV-8391]: https://webarchive.jira.com/browse/WEBDEV-8391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ