### PR TITLE
Fix singular/plural minute label at 1-minute loan boundary

### DIFF
--- a/src/components/timer-countdown.ts
+++ b/src/components/timer-countdown.ts
@@ -6,8 +6,12 @@ export class TimerCountdown extends LitElement {
   @property({ type: Number }) secondsLeftOnLoan = 0;
   @property({ type: Boolean }) displayTime = false;
 
+  private get totalMinutes(): number {
+    return Math.ceil(Math.round(this.secondsLeftOnLoan) / 60);
+  }
+
   get minutesLeftOnLoan(): string {
-    const totalMinutes = Math.ceil(Math.round(this.secondsLeftOnLoan) / 60);
+    const { totalMinutes } = this;
     if (totalMinutes < 10) return `0:0${totalMinutes}`;
     if (totalMinutes === 60) return `1:00`;
     return `0:${totalMinutes}`;
@@ -17,12 +21,9 @@ export class TimerCountdown extends LitElement {
   get remainingTime(): string {
     const unitOfTime = 'minute';
     const timeLeft = this.minutesLeftOnLoan;
-    // Preserves original (buggy) behavior: comparison was `timeLeft !== 1`
-    // against a string, so the plural branch always wins. Fixing this would
-    // change rendered output for the exactly-1-minute case.
-    return timeLeft !== ('1' as unknown as string)
-      ? `${timeLeft} ${unitOfTime}s`
-      : `${timeLeft} ${unitOfTime}`;
+    return this.totalMinutes === 1
+      ? `${timeLeft} ${unitOfTime}`
+      : `${timeLeft} ${unitOfTime}s`;
   }
 
   render(): TemplateResult {

--- a/test/components/timer-countdown.test.ts
+++ b/test/components/timer-countdown.test.ts
@@ -1,4 +1,4 @@
-import { html, fixture, expect, aTimeout } from '@open-wc/testing';
+import { html, fixture, expect } from '@open-wc/testing';
 import '../../src/ia-book-actions';
 import '../../src/components/timer-countdown';
 import type { TimerCountdown } from '../../src/components/timer-countdown';
@@ -18,9 +18,7 @@ const container = ({
     .loanRenewAtLast=${loanRenewAtLast}
   ></timer-countdown>`;
 
-describe('<timer-countdown>', async () => {
-  await aTimeout(5000);
-
+describe('<timer-countdown>', () => {
   it('timer interval is undefined when loan is expired', async () => {
     const el = (await fixture(
       container({
@@ -68,5 +66,49 @@ describe('<timer-countdown>', async () => {
 
     expect(el.minutesLeftOnLoan).to.equal('0:02');
     expect(el.remainingTime).to.equal('0:02 minutes');
+  });
+
+  it('renders singular "minute" for a handful of seconds under a minute', async () => {
+    const el = (await fixture(
+      container({ secondsLeftOnLoan: 5 }),
+    )) as TimerCountdown;
+
+    await el.updateComplete;
+
+    expect(el.minutesLeftOnLoan).to.equal('0:01');
+    expect(el.remainingTime).to.equal('0:01 minute');
+  });
+
+  it('renders singular "minute" when seconds are just under the 1-minute mark (rounds up)', async () => {
+    const el = (await fixture(
+      container({ secondsLeftOnLoan: 59 }),
+    )) as TimerCountdown;
+
+    await el.updateComplete;
+
+    expect(el.minutesLeftOnLoan).to.equal('0:01');
+    expect(el.remainingTime).to.equal('0:01 minute');
+  });
+
+  it('renders plural "minutes" when seconds are just over the 1-minute mark (rounds up to 2)', async () => {
+    const el = (await fixture(
+      container({ secondsLeftOnLoan: 61 }),
+    )) as TimerCountdown;
+
+    await el.updateComplete;
+
+    expect(el.minutesLeftOnLoan).to.equal('0:02');
+    expect(el.remainingTime).to.equal('0:02 minutes');
+  });
+
+  it('renders plural "minutes" when zero seconds remain', async () => {
+    const el = (await fixture(
+      container({ secondsLeftOnLoan: 0 }),
+    )) as TimerCountdown;
+
+    await el.updateComplete;
+
+    expect(el.minutesLeftOnLoan).to.equal('0:00');
+    expect(el.remainingTime).to.equal('0:00 minutes');
   });
 });

--- a/test/components/timer-countdown.test.ts
+++ b/test/components/timer-countdown.test.ts
@@ -47,4 +47,26 @@ describe('<timer-countdown>', async () => {
 
     expect(el.secondsLeftOnLoan).to.equal(2);
   });
+
+  it('renders singular "minute" at the 1-minute boundary', async () => {
+    const el = (await fixture(
+      container({ secondsLeftOnLoan: 60 }),
+    )) as TimerCountdown;
+
+    await el.updateComplete;
+
+    expect(el.minutesLeftOnLoan).to.equal('0:01');
+    expect(el.remainingTime).to.equal('0:01 minute');
+  });
+
+  it('renders plural "minutes" away from the 1-minute boundary', async () => {
+    const el = (await fixture(
+      container({ secondsLeftOnLoan: 120 }),
+    )) as TimerCountdown;
+
+    await el.updateComplete;
+
+    expect(el.minutesLeftOnLoan).to.equal('0:02');
+    expect(el.remainingTime).to.equal('0:02 minutes');
+  });
 });


### PR DESCRIPTION
remainingTime compared the formatted mm:ss string against the literal '1', which never matched, so the plural branch always rendered. Compare against the underlying totalMinutes count instead.

[WEBDEV-8470](https://webarchive.jira.com/browse/WEBDEV-8470)

[WEBDEV-8470]: https://webarchive.jira.com/browse/WEBDEV-8470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ