### PR TITLE
WEBDEV-8469: Fix browseagain/autoreturn never bumping loan-analytics counters

### DIFF
--- a/src/core/services/loan-analytics.ts
+++ b/src/core/services/loan-analytics.ts
@@ -71,11 +71,12 @@ export default class LoanAnanlytics {
     // parse time to just `'browse'` and `'return'` (since `'browse'`
     // is truthy), so `'browseagain'` and `'autoreturn'` actions never
     // matched any case — they fell through to `default` and were no-ops.
-    // Preserving that behavior verbatim. If `'browseagain'` /
-    // `'autoreturn'` should actually count, that's a real bug worth
-    // fixing in a separate ticket rather than silently in this migration.
+    // `'browseagain'`/`'autoreturn'` are real dispatched actions (see
+    // `ActionsHandler.bindEvents` for `browseBookAgain`/`autoReturn`) and
+    // are meant to bump the same counters as `'browse'`/`'return'`.
     switch (action) {
       case 'browse':
+      case 'browseagain':
         browse = browse ? Number(browse) + 1 : 1;
         this.gaStats.browse = browse;
         renew = 0;
@@ -86,6 +87,7 @@ export default class LoanAnanlytics {
         this.gaStats.renew = renew;
         break;
       case 'return':
+      case 'autoreturn':
         expire = expire ? Number(expire) + 1 : 1;
         this.gaStats.expire = expire;
         renew = 0;

--- a/test/core/services/loan-analytics.test.ts
+++ b/test/core/services/loan-analytics.test.ts
@@ -1,0 +1,41 @@
+import { expect } from '@open-wc/testing';
+
+import LoanAnanlytics from '../../../src/core/services/loan-analytics';
+import * as Cookies from '../../../src/core/services/doc-cookies';
+
+const identifier = 'identifier1';
+
+afterEach(() => {
+  Cookies.removeItem(`br-browse-${identifier}`, '/');
+});
+
+describe('Loan Analytics', () => {
+  it('browse bumps the browse counter', async () => {
+    const loanAnalytics = new LoanAnanlytics();
+    await loanAnalytics.storeLoanStatsCount(identifier, 'browse');
+
+    expect(loanAnalytics.lendingEventCounts?.browse).to.equal(1);
+  });
+
+  it('browseagain bumps the browse counter same as browse', async () => {
+    const loanAnalytics = new LoanAnanlytics();
+    await loanAnalytics.storeLoanStatsCount(identifier, 'browse');
+    await loanAnalytics.storeLoanStatsCount(identifier, 'browseagain');
+
+    expect(loanAnalytics.lendingEventCounts?.browse).to.equal(2);
+  });
+
+  it('return bumps the expire counter reported to GA', async () => {
+    const loanAnalytics = new LoanAnanlytics();
+    await loanAnalytics.storeLoanStatsCount(identifier, 'return');
+
+    expect(loanAnalytics.gaStats.expire).to.equal(1);
+  });
+
+  it('autoreturn bumps the expire counter same as return', async () => {
+    const loanAnalytics = new LoanAnanlytics();
+    await loanAnalytics.storeLoanStatsCount(identifier, 'autoreturn');
+
+    expect(loanAnalytics.gaStats.expire).to.equal(1);
+  });
+});


### PR DESCRIPTION
## Summary
- `getLoanStatsCount` in `loan-analytics.ts` used `case 'browse':` / `case 'return':` only, so the real dispatched actions `browseagain` (from `browseBookAgain`) and `autoreturn` (from `autoReturn`) silently fell through to `default` and never bumped their cookie-backed counters.
- The original JS source had `case 'browse' || 'browseagain':` / `case 'return' || 'autoreturn':`, which is a runtime OR expression evaluating to just `'browse'`/`'return'` at parse time — not a multi-case label — so this bug predates the TS migration. A prior commit on this branch (`3b5cb26`) explicitly reverted an attempt to fix this during the migration PR (#92) and punted it to this ticket.
- Decision (per ticket): both are real user-triggered events, so they should count — wired `browseagain` into the same case arm as `browse`, and `autoreturn` into the same arm as `return`.

## Test plan
- [x] Added `test/core/services/loan-analytics.test.ts` covering `browse`/`browseagain` and `return`/`autoreturn` parity
- [x] `yarn web-test-runner` — full suite passes (44/44)
- [x] `yarn lint` — no new issues introduced (pre-existing prettier-version-mismatch warnings unrelated to these lines)

https://webarchive.jira.com/browse/WEBDEV-8469